### PR TITLE
Add zai-org/GLM-5.1 and moonshotai/Kimi-K2.6 to local vLLM serving

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,30 @@ Running a local model is a two-step process: first **serve** the model with vLLM
   --serve-job 12345
 ```
 
+#### Huge-model example (GLM-5.1)
+
+> **Not recommended.** `zai-org/GLM-5.1` is roughly **10× slower** than
+> `moonshotai/Kimi-K2.6` on the same hardware (~7.5 vs ~86 tok/s single-request).
+> The bottleneck is `--enforce-eager`, which is required to avoid a DeepGEMM JIT
+> crash in GLM's `glm_moe_dsa` sparse-attention path during CUDA graph capture.
+> Eager mode disables CUDA graphs and `torch.compile`, which is the dominant
+> speedup we get on Kimi. Until that DeepGEMM/`torch.compile` interaction is
+> fixed upstream, prefer Kimi-K2.6 for evals on this stack.
+
+```bash
+./serve/serve.slurm \
+  --model zai-org/GLM-5.1 \
+  --nodes 3 \
+  --gpus-per-node 8
+
+./serve/eval.slurm \
+  --model zai-org/GLM-5.1 \
+  --problem problems/critpt/quantum_error_correction_main.yaml \
+  --serve-job <JOB_ID>
+```
+
+`zai-org/GLM-5.1` is very large; in our Slurm tests it required 3 nodes (`--nodes 3`) with 8 GPUs per node.
+
 #### Prerequisites
 
 - `uv sync --extra local`
@@ -227,6 +251,8 @@ Running a local model is a two-step process: first **serve** the model with vLLM
 #### Step 1: Serve the model
 
 Use `serve/serve.slurm`. The script self-submits with `sbatch`, launches one `vllm serve` rank per allocated node, stores Slurm logs under `serve/logs/`, and writes connection details to `serve/logs/vllm/<job_id>/endpoint.env`.
+
+For huge local models, the default serve wall time is 24 hours and `serve/eval.slurm` will wait up to 4 hours for the endpoint to become healthy before giving up.
 
 ```bash
 # Qwen on 1 node, 1 GPU
@@ -245,7 +271,19 @@ Use `serve/serve.slurm`. The script self-submits with `sbatch`, launches one `vl
 # Nemotron Super on 2 nodes, 8 GPUs per node
 ./serve/serve.slurm \
   --model nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16 \
-  --nodes 1 \
+  --nodes 2 \
+  --gpus-per-node 8
+
+# GLM-5.1 on 3 nodes, 8 GPUs per node
+./serve/serve.slurm \
+  --model zai-org/GLM-5.1 \
+  --nodes 3 \
+  --gpus-per-node 8
+
+# Kimi-K2.6 on 4 nodes, 8 GPUs per node
+./serve/serve.slurm \
+  --model moonshotai/Kimi-K2.6 \
+  --nodes 4 \
   --gpus-per-node 8
 
 # Nemotron Cascade on 1 node, 1 GPU
@@ -257,12 +295,40 @@ Use `serve/serve.slurm`. The script self-submits with `sbatch`, launches one `vl
 
 The `--reasoning-parser` flag is exposed directly. Use it to enable built-in parsers such as `qwen3`. For `nano_v3` and `super_v3`, the script automatically attaches the matching plugin file from `serve/reasoning_parsers`.
 
+#### Performance tuning notes for huge models
+
+Per-model `vllm_args` in `models.yaml` already encode the fastest configuration we found on our cluster (4×H100 80 GB nodes, WekaFS-backed weights). The full experiment log is in the comments above each entry; the headline results:
+
+Load times below are wall time of `default_loader.py` "Loading weights took N seconds" on the slowest worker. They depend heavily on whether the OS page cache is warm.
+
+| Model | Tput (single req) | Tput (8-way batch) | Load (cold cache) | Load (warm cache) | Notes |
+|-------|-------------------|--------------------|-------------------|-------------------|-------|
+| `zai-org/GLM-5.1`      | ~7.5 tok/s | ~50 tok/s  | ~2.5h (no prefetch) → ~2 min (with prefetch, projected) | ~37 min (no prefetch) → **~2 min (with prefetch, chosen)** | `--enforce-eager` is **required** (DeepGEMM JIT crash without it). EP gives 0% gain. |
+| `moonshotai/Kimi-K2.6` | ~90 tok/s  | ~335 tok/s | ~78 min (no prefetch); prefetch on cold cache untested | ~6-9 min (no prefetch ≈ prefetch) | CUDA graphs (no `--enforce-eager`) give the dominant 4× throughput win; `--enable-expert-parallel` adds ~3-4%. |
+
+Two flags worth knowing whenever you add a new huge model on a networked filesystem:
+
+- `--safetensors-load-strategy prefetch` — pulls all shards into the OS page cache via background threads. Mandatory on WekaFS / Lustre / NFS where vLLM's auto-detection often misses and falls back to slow random mmap reads. Confirmed 17× speedup on GLM-5.1 even on a warm cache (282 shards); on Kimi-K2.6 (64 shards) it's a no-op once the cache is warm but still recommended for the very first load.
+- `--enable-expert-parallel` — for MoE models with many experts (Kimi has 384), shard them across the TP group rather than replicate. Free win for Kimi-class models.
+
+What does **not** help on H100:
+
+- `--load-format runai_streamer` — slower than `prefetch` on Weka (~6 min vs ~2 min for GLM on a warm cache).
+- FlashAttention 4 — only supported on Blackwell (SM100+); Hopper falls back to FA3 (which is already what we use).
+- ngram / EAGLE / Medusa / MTP / suffix speculative decoding for Kimi-K2.6 — all blocked: Kimi-K2.6 dropped MTP layers, no draft weights ship with it, suffix decoding's `arctic-inference` build needs C++20 `<span>` (GCC 9.4 lacks it), and ngram is incompatible with PP > 1 in vLLM 0.19.1. Pure-TP multi-node ngram works but is slower than the no-spec config because inter-node TP all-reduce dominates.
+- `--kv-cache-dtype fp8` for Kimi-K2.6 — ~18% slower single-request (per-step dequant) and the only benefit is ~50% KV-cache memory, which is unused: the champion runs at ~12-15% KV utilization at 8-way concurrency.
+- Reducing pipeline parallelism (PP=2/TP=8 on 2 nodes vs PP=4/TP=8 on 4 nodes) — gives linear per-GPU scaling (~43 vs ~90 tok/s single-req), no per-request latency win from fewer stages.
+
+To go faster than the per-replica ceiling here, the right axis is **data parallelism**: run more replicas of the 4-node Kimi serve and put a small OpenAI-compatible router in front so the eval client still sees one endpoint. That work is intentionally not in this PR.
+
 Local model keys match Hub repo IDs:
 
 - `Qwen/Qwen3.5-4B`
 - `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16`
 - `nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16`
 - `nvidia/Nemotron-Cascade-2-30B-A3B`
+- `moonshotai/Kimi-K2.6` (4 nodes; 1T-parameter MoE, native int4 quantization)
+- `zai-org/GLM-5.1` (3 nodes; sparse-attention MoE — see "Not recommended" note above)
 
 #### Step 2: Run the problem
 
@@ -286,6 +352,20 @@ uv run python -m open_dirac.one_shot \
 ```
 
 The Python vLLM provider defaults to `http://localhost:8000/v1` but respects the `VLLM_BASE_URL` environment variable, which overrides the default with the serve job's head node IP.
+
+#### Step 3 (optional): Full benchmark sweep
+
+To run the **entire CritPt set (70 problems) in parallel** against a vLLM serve job, use `serve/full_eval.slurm`. It auto-fans out via `scripts/run_critpt_oneshot.py`, with `--concurrency` parallel in-flight requests sharing the same endpoint:
+
+```bash
+./serve/full_eval.slurm \
+  --model moonshotai/Kimi-K2.6 \
+  --serve-job <SERVE_JOB_ID> \
+  --concurrency 8 \
+  --time 8:00:00
+```
+
+Submission JSONs land in `results/critpt_oneshot/<model_slug>/<timestamp>/`. To resume an interrupted run, pass `--resume <DIR>` pointing at that timestamped directory; completed problems are skipped automatically and the original generation/run config is reloaded from `batch_metadata.json`.
 
 ## Scripts
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,17 +15,28 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=8.0", "pytest-cov"]
+dev = ["pytest>=8.0"]
 openai = ["openai>=1.0"]
 google = ["google-genai>=1.0"]
 huggingface = ["huggingface-hub>=0.25"]
 all-providers = ["openai>=1.0", "google-genai>=1.0", "huggingface-hub>=0.25"]
 local = [
-    "vllm==0.19.0; sys_platform == 'linux'",
-    "flashinfer-python==0.6.6; sys_platform == 'linux'",
-    "flashinfer-cubin==0.6.6; sys_platform == 'linux'",
+    # vLLM 0.20.0 is tagged on GitHub (2026-04-23) but not yet on PyPI; the
+    # latest pypi release is 0.19.1. Bump to >=0.20 once it ships. vLLM
+    # already pins flashinfer-{python,cubin}==0.6.6 transitively, so we don't
+    # need to list them here.
+    "vllm>=0.19.1; sys_platform == 'linux'",
+    # GLM-5.1's `glm_moe_dsa` architecture requires transformers >= 5.5.4;
+    # vLLM only requires >=4.56.0 so we pin the floor explicitly.
+    "transformers>=5.5.4; sys_platform == 'linux'",
     "hf-transfer; sys_platform == 'linux'",
+    # GLM-5.1 needs DeepGEMM kernels for its sparse-attention indexer.
+    # Wheel is checked into the repo (it's not on PyPI); see [tool.uv.sources].
+    "deep-gemm; sys_platform == 'linux'",
 ]
+
+[tool.uv.sources]
+deep-gemm = { path = "deep_gemm-2.3.0+477618c-cp313-cp313-linux_x86_64.whl" }
 
 [project.scripts]
 open_dirac = "open_dirac.main:main"

--- a/scripts/run_critpt_common.py
+++ b/scripts/run_critpt_common.py
@@ -420,6 +420,26 @@ def write_batch_metadata(
     os.replace(tmp_path, final_path)
 
 
+def write_initial_batch_metadata(
+    output_dir: Path,
+    critpt_model: str,
+    generation_config: dict,
+    run_config: dict,
+    start_time: datetime,
+) -> None:
+    """Write a stub ``batch_metadata.json`` before any workers spawn.
+
+    Makes a partially-completed run resumable via ``--resume`` even if the
+    process is killed before the end-of-run ``write_batch_metadata`` call.
+    The stub records the run's configs and an empty problems list; the
+    end-of-run write merges per-problem results into it.
+    """
+    write_batch_metadata(
+        output_dir, critpt_model, [],
+        generation_config, run_config, start_time, start_time,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Orchestration helpers
 # ---------------------------------------------------------------------------

--- a/scripts/run_critpt_oneshot.py
+++ b/scripts/run_critpt_oneshot.py
@@ -30,7 +30,7 @@ from run_critpt_common import (
     resolve_critpt_model_string, discover_problems,
     load_resume_config, find_completed_submissions,
     resolve_model, make_output_dir,
-    write_submission_json, write_batch_metadata,
+    write_submission_json, write_batch_metadata, write_initial_batch_metadata,
     save_raw_response, setup_signal_handler, print_final_summary,
 )
 from open_dirac.verification.evaluate import extract_answer_code  # noqa: E402
@@ -263,6 +263,10 @@ async def run_batch(args: argparse.Namespace) -> int:
     # Run with semaphore-controlled concurrency
     semaphore = asyncio.Semaphore(args.concurrency)
     start_time = datetime.now(timezone.utc)
+    # Stub metadata so a killed run is resumable before any workers finish.
+    write_initial_batch_metadata(
+        output_dir, critpt_model, generation_config, run_config, start_time,
+    )
     total = len(problems)
     completed_count = 0
     succeeded = 0

--- a/scripts/run_critpt_open_dirac.py
+++ b/scripts/run_critpt_open_dirac.py
@@ -30,7 +30,7 @@ from run_critpt_common import (
     resolve_critpt_model_string, discover_problems,
     load_resume_config, find_completed_submissions,
     resolve_model, make_output_dir,
-    write_submission_json, write_batch_metadata,
+    write_submission_json, write_batch_metadata, write_initial_batch_metadata,
     setup_signal_handler, print_final_summary,
 )
 
@@ -396,6 +396,9 @@ async def run_batch(args: argparse.Namespace) -> int:
     # Run
     semaphore = asyncio.Semaphore(args.concurrency)
     start_time = datetime.now(timezone.utc)
+    write_initial_batch_metadata(
+        output_dir, critpt_model, generation_config, run_config, start_time,
+    )
     total = len(to_run)
     completed = 0
     succeeded = 0

--- a/scripts/run_critpt_rsa.py
+++ b/scripts/run_critpt_rsa.py
@@ -30,7 +30,7 @@ from run_critpt_common import (
     resolve_critpt_model_string, discover_problems,
     load_resume_config, find_completed_submissions,
     resolve_model, make_output_dir,
-    write_submission_json, write_batch_metadata,
+    write_submission_json, write_batch_metadata, write_initial_batch_metadata,
     save_raw_response, setup_signal_handler, print_final_summary,
 )
 from open_dirac.verification.evaluate import extract_answer_code  # noqa: E402
@@ -306,6 +306,9 @@ async def run_batch(args: argparse.Namespace) -> int:
     # Run with semaphore-controlled concurrency
     semaphore = asyncio.Semaphore(args.concurrency)
     start_time = datetime.now(timezone.utc)
+    write_initial_batch_metadata(
+        output_dir, critpt_model, generation_config, run_config, start_time,
+    )
     total = len(problems)
     completed_count = 0
     succeeded = 0

--- a/serve/eval.slurm
+++ b/serve/eval.slurm
@@ -33,6 +33,18 @@ Examples:
     --problem problems/critpt/quantum_error_correction_main.yaml \
     --serve-job 22071810
 
+  # Huge local vLLM model
+  ./serve/eval.slurm \
+    --model zai-org/GLM-5.1 \
+    --problem problems/critpt/quantum_error_correction_main.yaml \
+    --serve-job 22071810
+
+  # Local vLLM Kimi-K2.6
+  ./serve/eval.slurm \
+    --model moonshotai/Kimi-K2.6 \
+    --problem problems/critpt/quantum_error_correction_main.yaml \
+    --serve-job 22071810
+
   # Batch run (10 samples)
   ./serve/eval.slurm \
     --model qwen-3.5-0.8b-local \
@@ -54,7 +66,7 @@ Options:
                        exports VLLM_BASE_URL to reach the head node IP.
   --partition NAME     Slurm partition (default: hopper-cpu; overridden to
                        hopper-prod when --serve-job is used).
-  --time HH:MM:SS      Slurm time limit (default: 02:00:00).
+  --time HH:MM:SS      Slurm time limit (default: 08:00:00).
   -h, --help           Show this message.
 USAGE
 }
@@ -74,7 +86,7 @@ PROBLEM=""
 RUNS=""
 SERVE_JOB=""
 PARTITION=""
-TIME_LIMIT="02:00:00"
+TIME_LIMIT="08:00:00"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -210,11 +222,11 @@ if [[ -n "$SERVE_JOB" ]]; then
   export VLLM_BASE_URL="${BASE_URL}"
   echo "Serve job ${SERVE_JOB}: endpoint ${BASE_URL}"
 
-  # Wait for vLLM to be ready (models can take 10+ minutes to compile).
+  # Wait for vLLM to be ready (huge models can take a long time to load).
   echo "Waiting for vLLM endpoint to be ready..."
   HEALTH_URL="http://${HEAD_IP}:${PORT:-8000}/health"
   WAIT_SECS=0
-  MAX_WAIT=1800  # 30 minutes
+  MAX_WAIT=14400  # 4 hours
   until curl -sf "$HEALTH_URL" >/dev/null 2>&1; do
     if (( WAIT_SECS >= MAX_WAIT )); then
       echo "Timed out waiting for vLLM after ${MAX_WAIT}s" >&2

--- a/serve/full_eval.slurm
+++ b/serve/full_eval.slurm
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Run the full CritPt benchmark (70 problems) against a vLLM serve job.
+#
+# Usage:
+#   ./serve/full_eval.slurm --model MODEL_KEY --serve-job JOB_ID [--concurrency N] [--time HH:MM:SS]
+#
+# Self-submits via sbatch when run outside Slurm. Reads endpoint.env from the
+# serve job and exports VLLM_BASE_URL so the parallel client connects to the
+# serve head node.
+
+set -euo pipefail
+
+if [[ -n "${SLURM_SUBMIT_DIR:-}" ]]; then
+  REPO_ROOT="$(cd "${SLURM_SUBMIT_DIR}" && pwd)"
+  SCRIPT_PATH="${REPO_ROOT}/serve/full_eval.slurm"
+else
+  SCRIPT_PATH="$(realpath "${BASH_SOURCE[0]}")"
+  REPO_ROOT="$(cd "$(dirname "${SCRIPT_PATH}")/.." && pwd)"
+fi
+LOG_ROOT="${REPO_ROOT}/serve/logs"
+LOG_DIR_DEFAULT="${LOG_ROOT}/slurm"
+
+MODEL_KEY=""
+SERVE_JOB=""
+CONCURRENCY="10"
+TIME_LIMIT="08:00:00"
+RESUME_DIR=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --model) MODEL_KEY="$2"; shift 2 ;;
+    --serve-job) SERVE_JOB="$2"; shift 2 ;;
+    --concurrency) CONCURRENCY="$2"; shift 2 ;;
+    --time) TIME_LIMIT="$2"; shift 2 ;;
+    --resume) RESUME_DIR="$2"; shift 2 ;;
+    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ -z "$MODEL_KEY" || -z "$SERVE_JOB" ]]; then
+  echo "Usage: $0 --model MODEL_KEY --serve-job JOB_ID [--concurrency N] [--time HH:MM:SS] [--resume DIR]" >&2
+  exit 1
+fi
+
+if [[ -z "${SLURM_JOB_ID:-}" ]]; then
+  MODEL_SLUG="${MODEL_KEY//[^[:alnum:]]/-}"
+  while [[ "$MODEL_SLUG" == *--* ]]; do MODEL_SLUG="${MODEL_SLUG//--/-}"; done
+  MODEL_SLUG="${MODEL_SLUG#-}"; MODEL_SLUG="${MODEL_SLUG%-}"
+  JOB_NAME="critpt-full-${MODEL_SLUG}"
+  mkdir -p "$LOG_DIR_DEFAULT"
+
+  ENDPOINT_ENV="${LOG_ROOT}/vllm/${SERVE_JOB}/endpoint.env"
+  [[ -f "$ENDPOINT_ENV" ]] || { echo "endpoint.env not found: $ENDPOINT_ENV" >&2; exit 1; }
+  # shellcheck disable=SC1090
+  source "$ENDPOINT_ENV"
+  echo "Serve job ${SERVE_JOB}: endpoint ${BASE_URL}"
+
+  RESUME_ARG=()
+  [[ -n "$RESUME_DIR" ]] && RESUME_ARG=(--resume "$RESUME_DIR")
+
+  exec sbatch --parsable \
+    --job-name "$JOB_NAME" \
+    --partition hopper-prod \
+    --nodes 1 --ntasks-per-node 1 --cpus-per-task 16 --mem=64G \
+    --time "$TIME_LIMIT" \
+    --output "${LOG_DIR_DEFAULT}/%x-%j.out" \
+    --error "${LOG_DIR_DEFAULT}/%x-%j.err" \
+    "$SCRIPT_PATH" --model "$MODEL_KEY" --serve-job "$SERVE_JOB" \
+                   --concurrency "$CONCURRENCY" --time "$TIME_LIMIT" \
+                   "${RESUME_ARG[@]}"
+fi
+
+# ── Inside Slurm ─────────────────────────────────────────────────────────────
+[[ -f "$HOME/.bashrc" ]] && source "$HOME/.bashrc"
+cd "$REPO_ROOT"
+
+ENDPOINT_ENV="${LOG_ROOT}/vllm/${SERVE_JOB}/endpoint.env"
+# shellcheck disable=SC1090
+source "$ENDPOINT_ENV"
+export VLLM_BASE_URL="${BASE_URL}"
+
+echo "Waiting for vLLM endpoint ${BASE_URL}..."
+HEALTH_URL="http://${HEAD_IP}:${PORT:-8000}/health"
+WAIT=0; MAX=14400
+until curl -sf "$HEALTH_URL" >/dev/null 2>&1; do
+  (( WAIT >= MAX )) && { echo "Timed out after ${MAX}s" >&2; exit 1; }
+  sleep 15; WAIT=$(( WAIT + 15 ))
+done
+echo "vLLM ready after ${WAIT}s."
+
+RESUME_ARG=()
+[[ -n "$RESUME_DIR" ]] && RESUME_ARG=(--resume "$RESUME_DIR")
+
+exec uv run --no-sync python scripts/run_critpt_oneshot.py \
+  --model "$MODEL_KEY" --concurrency "$CONCURRENCY" --timeout 3600 \
+  "${RESUME_ARG[@]}"

--- a/serve/resolve_serve_config.py
+++ b/serve/resolve_serve_config.py
@@ -20,6 +20,7 @@ def main():
     models_yaml = Path(__file__).resolve().parent.parent / "src" / "open_dirac" / "models.yaml"
 
     serve: dict = {}
+    model_id: str = model
     try:
         with open(models_yaml) as f:
             registry = yaml.safe_load(f)
@@ -27,9 +28,13 @@ def main():
             entry = registry.get(model)
             if entry and isinstance(entry, dict):
                 serve = entry.get("serve") or {}
+                # Allow an alias key (e.g. zai-org/GLM-5.1-runai) to resolve
+                # to a different upstream HF repo via `model_id`.
+                model_id = entry.get("model_id") or model
     except (OSError, yaml.YAMLError) as exc:
         print(f"Warning: could not read {models_yaml}: {exc}", file=sys.stderr)
 
+    nodes = str(serve.get("nodes", ""))
     gpus = str(serve.get("gpus_per_node", 1))
     parser = serve.get("reasoning_parser", "")
     vllm_args = serve.get("vllm_args", [])
@@ -42,6 +47,8 @@ def main():
     for arg in vllm_args:
         tokens.extend(shlex.split(str(arg)))
 
+    print(f"DEFAULT_MODEL_ID={shlex.quote(model_id)}")
+    print(f"DEFAULT_NODES={shlex.quote(nodes)}")
     print(f"DEFAULT_GPUS_PER_NODE={shlex.quote(gpus)}")
     print(f"DEFAULT_REASONING_PARSER={shlex.quote(parser)}")
     quoted = " ".join(shlex.quote(t) for t in tokens)

--- a/serve/serve.slurm
+++ b/serve/serve.slurm
@@ -27,15 +27,17 @@ Examples:
   ./serve/serve.slurm --model Qwen/Qwen3.5-4B --nodes 1 --gpus-per-node 1
   ./serve/serve.slurm --model nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16 --nodes 1 --gpus-per-node 1
   ./serve/serve.slurm --model nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16 --nodes 2 --gpus-per-node 8
+  ./serve/serve.slurm --model zai-org/GLM-5.1 --nodes 3 --gpus-per-node 8
+  ./serve/serve.slurm --model moonshotai/Kimi-K2.6 --nodes 4 --gpus-per-node 8
   ./serve/serve.slurm --model Qwen/Qwen3.5-4B --nodes 1 --gpus-per-node 1 --reasoning-parser qwen3
 
 Options:
   --model MODEL                    Hugging Face model repo id to serve.
-  --nodes N                        Node count. Defaults to 1 when self-submitting.
+  --nodes N                        Node count. Defaults to serve.nodes or 1 when self-submitting.
   --gpus-per-node N                GPU count per node. Defaults are model-specific.
   --partition NAME                 Slurm partition (default: hopper-prod).
   --cpus-per-task N                CPUs per task. Defaults to 11 * gpus-per-node.
-  --time HH:MM:SS                  Slurm time limit (default: 04:00:00).
+  --time HH:MM:SS                  Slurm time limit (default: 24:00:00).
   --port PORT                      vLLM API port (default: 8000).
   --served-model-name NAME         Model name exposed by the API (default: MODEL).
   --max-model-len TOKENS           Max model length (default: 262144).
@@ -148,7 +150,7 @@ NODES=""
 GPUS_PER_NODE=""
 PARTITION="hopper-prod"
 CPUS_PER_TASK=""
-TIME_LIMIT="04:00:00"
+TIME_LIMIT="24:00:00"
 PORT="8000"
 SERVED_MODEL_NAME=""
 MAX_MODEL_LEN="262144"
@@ -249,6 +251,9 @@ _RESOLVE_SCRIPT="${SCRIPT_DIR}/resolve_serve_config.py"
 eval "$(uv run --no-sync python "$_RESOLVE_SCRIPT" "$MODEL")"
 
 if [[ -z "${SLURM_JOB_ID:-}" ]]; then
+  if [[ -z "$NODES" ]]; then
+    NODES="$DEFAULT_NODES"
+  fi
   if [[ -z "$NODES" ]]; then
     NODES="1"
   fi
@@ -385,8 +390,15 @@ if ! is_pos_int "$PORT"; then
 fi
 
 if [[ -z "$SERVED_MODEL_NAME" ]]; then
-  SERVED_MODEL_NAME="$MODEL"
+  # Default the served name to the upstream HF repo (`model_id` from
+  # models.yaml) so OpenAI clients can call the API with the same name they
+  # use everywhere else. This matters for alias entries like
+  # `zai-org/GLM-5.1-runai` whose `model_id` is `zai-org/GLM-5.1`.
+  SERVED_MODEL_NAME="${DEFAULT_MODEL_ID:-$MODEL}"
 fi
+# Use the real HF repo id for vLLM's `serve` argument; the alias is only
+# meaningful inside open-dirac's models.yaml.
+MODEL_ID="${DEFAULT_MODEL_ID:-$MODEL}"
 if [[ -z "$REASONING_PARSER" ]]; then
   REASONING_PARSER="$DEFAULT_REASONING_PARSER"
 fi
@@ -412,7 +424,7 @@ if (( TP * PP != TOTAL_ASSIGNED_GPUS )); then
 fi
 
 VLLM_ARGS=(
-  serve "$MODEL"
+  serve "$MODEL_ID"
   --host 0.0.0.0
   --port "$PORT"
   --served-model-name "$SERVED_MODEL_NAME"

--- a/src/open_dirac/models.yaml
+++ b/src/open_dirac/models.yaml
@@ -279,3 +279,131 @@ nvidia/Nemotron-Cascade-2-30B-A3B:
       - --mamba-ssm-cache-dtype float32
       - --enable-auto-tool-choice
       - --tool-call-parser qwen3_coder
+
+# GLM-5.1: 3 nodes (24 H100), prefetch loader + eager. ~7.5 tok/s single-req.
+#
+# Experiments tried (all kept here as a record - none beat this config):
+# - --safetensors-load-strategy prefetch  → CHOSEN. Worker weight load went
+#   from 2214s (~37 min, warm page cache, no prefetch) to 128s (~2 min, warm
+#   page cache, prefetch) — a ~17x speedup just from running the shard reads
+#   in background threads. Cold-cache, no-prefetch was even worse: a first
+#   load only reached 29% of 282 shards in 44 min before we cancelled it,
+#   projecting to ~2.5h total.
+# - --load-format runai_streamer  → REJECTED. ~6 min load vs ~2 min prefetch
+#   on a warm cache. Multi-threaded direct CPU→GPU streaming is slower than
+#   letting the OS page cache stay warm.
+# - --enforce-eager  → REQUIRED. Without it, GLM's `glm_moe_dsa` sparse-
+#   attention indexer hits CUDA_ERROR_FILE_NOT_FOUND in DeepGEMM's JIT during
+#   torch.compile graph capture. Eager skips the capture path.
+# - --enable-expert-parallel  → REJECTED. Measured 7.5 tok/s, identical to
+#   baseline. GLM has fewer experts than Kimi (32 vs 384), so PP=3/TP=8
+#   already distributes them well; explicit EP adds nothing.
+# - ngram speculative decoding → BLOCKED. vLLM 0.19.1 explicitly disallows
+#   spec decoding with PP > 1 (see vLLM bugs #30436, #35521).
+zai-org/GLM-5.1:
+  provider: vllm
+  model_id: zai-org/GLM-5.1
+  env_key: VLLM_API_KEY
+  input_cost: 0.0
+  output_cost: 0.0
+  max_output_tokens: 131072
+  reasoning_format: separate_field
+  tool_mode: api
+  serve:
+    nodes: 3
+    gpus_per_node: 8
+    vllm_args:
+      - --max-model-len 163840
+      - --trust-remote-code
+      - --safetensors-load-strategy prefetch
+      - --enforce-eager
+
+# Kimi-K2.6: 4 nodes (32 H100). ~90 tok/s single-request, ~335 tok/s aggregate
+# at 8-way concurrency. ~4x faster than the original eager-mode baseline.
+#
+# Experiments tried (all kept here as a record):
+# - WINNERS:
+#   - drop --enforce-eager  → 4x throughput (~22 → ~90 tok/s). Kimi's CUDA
+#     graphs / torch.compile path works fine, unlike GLM's. Single biggest
+#     win in the whole sweep.
+#   - --enable-expert-parallel  → +3-4% on single-request, marginal but free.
+#   - --safetensors-load-strategy prefetch  → KEPT but only matters on a
+#     COLD page cache. First-ever Kimi load on cold WekaFS took 4692s
+#     (~78 min, no prefetch). Subsequent warm-cache loads were 380-560s
+#     (~6-9 min) regardless of whether prefetch was on. So this flag is
+#     defensive: it should give a similar ~10x speedup the first time the
+#     cluster touches Kimi, and is a no-op afterwards.
+# - DEAD ENDS:
+#   - --enable-expert-parallel WITH --enforce-eager → 20.8 tok/s, no win.
+#     The CUDA-graph speedup is the dominant factor; EP only helps once
+#     graphs are on.
+#   - MTP speculative decoding → BLOCKED. Kimi-K2.6's HF config has
+#     num_nextn_predict_layers=0 (K2.6 dropped K2's MTP layers).
+#   - EAGLE/Medusa speculative decoding → BLOCKED. No draft weights ship
+#     with K2.6.
+#   - Suffix speculative decoding → BLOCKED. Requires arctic-inference,
+#     which fails to build here (CMake needs C++20 <span>; system GCC 9.4
+#     lacks it).
+#   - ngram / ngram_gpu speculative decoding (PP=4) → CRASHED. vLLM 0.19.1
+#     spec decoding is unsupported with PP > 1: hit two different bugs.
+#     #30436 (drafter attr accessed on non-last PP rank) is workaroundable
+#     with a one-line `hasattr(self, "drafter")` guard around the spec-decode
+#     metadata block in `vllm/v1/worker/gpu_model_runner.py` (~line 2310);
+#     PR #31266 will fix this upstream. The second bug (a scheduler
+#     `total_num_scheduled_tokens > 0` assert) has no good workaround. So
+#     don't bother applying the patch unless you've also resolved that.
+#   - ngram speculative decoding (PP=2/TP=8) → CRASHED. Same PP+spec issue.
+#   - ngram speculative decoding (single-node TP=8/PP=1/EP) → CRASHED with
+#     a torch._inductor JIT autotuning CUDA_ERROR_FILE_NOT_FOUND
+#     (analogous to GLM's DeepGEMM crash); would have needed --enforce-eager
+#     which kills the throughput win.
+#   - ngram speculative decoding (multi-node TP=16/PP=1/EP, with explicit
+#     `--tp 16 --pp 1` to override serve.slurm's PP=nodes default) → RAN
+#     successfully but only 40-45 tok/s (half the champion). Inter-node TP
+#     all-reduce on IB is 10x slower than intra-node NVLink, and ngram's
+#     12-16% acceptance rate isn't enough to compensate. Also: max-model-len
+#     had to drop from 262k to 131k and gpu-memory-utilization from 0.9 to
+#     0.85 to avoid mid-generation OOM with the ngram drafter buffers.
+#   - --kv-cache-dtype fp8 (champion + fp8 KV-cache) → REJECTED. Warm
+#     single-req ~74 tok/s vs ~90 bf16 (~18% slower from per-step dequant
+#     overhead). The only benefit is ~50% KV-cache memory, which we don't
+#     need: the champion runs at ~12-15% KV utilization at 8-way concurrency.
+#   - PP=2/TP=8 on 2 nodes (half the champion's resources) → ~43 tok/s
+#     single-req vs 90 tok/s on 32 GPUs. Linear per-GPU scaling, no
+#     per-request win from fewer pipeline stages. Confirms that further PP
+#     reduction does not unlock single-request latency on Kimi.
+#   - Data-parallel scaling across replicas was not exercised here — needs
+#     a tiny OpenAI-compatible router in front to keep the eval client
+#     unchanged. Punted to a follow-up PR. This is the right next axis when
+#     more nodes are available.
+# - NOT APPLICABLE:
+#   - FlashAttention 4 → not supported on H100 (FA4 needs SM100+ Blackwell;
+#     also doesn't support MLA's non-standard head dims). Kimi already uses
+#     FA3, which IS the latest FA on Hopper.
+moonshotai/Kimi-K2.6:
+  provider: vllm
+  model_id: moonshotai/Kimi-K2.6
+  env_key: VLLM_API_KEY
+  input_cost: 0.0
+  output_cost: 0.0
+  # Half of --max-model-len so prompts (a few thousand tokens) fit alongside
+  # the generation budget without overflowing the model's context window.
+  max_output_tokens: 131072
+  reasoning_format: separate_field
+  tool_mode: api
+  serve:
+    nodes: 4
+    gpus_per_node: 8
+    vllm_args:
+      - --max-model-len 262144
+      - --trust-remote-code
+      - --safetensors-load-strategy prefetch
+      - --enable-expert-parallel
+
+# NOTE: deepseek-ai/DeepSeek-V4-Pro (1.6T MoE, novel CSA+HCA attention,
+# released 2026-04-24) is NOT runnable on our stack. Two blockers:
+#   1. transformers does not recognise model_type="deepseek_v4".
+#   2. vLLM 0.19.1's model registry has no DeepseekV4ForCausalLM entry; only
+#      V2/V3/V3.2 + GlmMoeDsa. Even hacking transformers won't help - vLLM
+#      has no kernels for the new sparse attention.
+# Revisit once vLLM 0.20+ ships DSV4 support.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,8 @@
 """Tests for config loading, YAML merge, and CLI parsers."""
 
-import tempfile
+import shlex
+import subprocess
+import sys
 import warnings
 from argparse import Namespace
 from pathlib import Path
@@ -9,6 +11,10 @@ import pytest
 import yaml
 
 from open_dirac.config import Config, DEFAULTS, _YAML_CONFIG_FIELDS, load_config_yaml, build_config
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+MODELS_YAML = PROJECT_ROOT / "src" / "open_dirac" / "models.yaml"
+RESOLVE_SERVE_CONFIG = PROJECT_ROOT / "serve" / "resolve_serve_config.py"
 
 
 # ---------------------------------------------------------------------------
@@ -153,6 +159,111 @@ class TestBuildConfig:
         # Attempted override is ignored; value comes from models.yaml
         assert cfg.max_tokens == 65536
         assert cfg.max_iterations == 10
+
+
+# ---------------------------------------------------------------------------
+# Model registry resolution
+# ---------------------------------------------------------------------------
+
+class TestModelRegistryResolution:
+    def test_glm_5_1_local_vllm_key_resolves(self):
+        cfg = Config(model="zai-org/GLM-5.1")
+        assert cfg.provider == "vllm"
+        assert cfg.model_id == "zai-org/GLM-5.1"
+        assert cfg.max_tokens == 131072
+        assert cfg.reasoning["reasoning_format"] == "separate_field"
+        assert cfg.reasoning["tool_mode"] == "api"
+
+    def test_kimi_k2_6_local_vllm_key_resolves(self):
+        cfg = Config(model="moonshotai/Kimi-K2.6")
+        assert cfg.provider == "vllm"
+        assert cfg.model_id == "moonshotai/Kimi-K2.6"
+        assert cfg.max_tokens == 131072
+        assert cfg.reasoning["reasoning_format"] == "separate_field"
+        assert cfg.reasoning["tool_mode"] == "api"
+
+
+# ---------------------------------------------------------------------------
+# models.yaml `serve` block — consumed by serve/serve.slurm
+# ---------------------------------------------------------------------------
+
+class TestServeConfig:
+    """The serve.slurm script reads `serve.{nodes,gpus_per_node,vllm_args}` for
+    each model. These tests pin the contract for the two new huge models so a
+    drive-by yaml edit cannot silently break the launcher."""
+
+    @pytest.fixture(scope="class")
+    def registry(self) -> dict:
+        return yaml.safe_load(MODELS_YAML.read_text())
+
+    def test_glm_5_1_serve_block(self, registry):
+        serve = registry["zai-org/GLM-5.1"]["serve"]
+        assert serve["nodes"] == 3
+        assert serve["gpus_per_node"] == 8
+        args = " ".join(serve["vllm_args"])
+        assert "--enforce-eager" in args  # mandatory: DeepGEMM JIT crash without it
+        assert "--safetensors-load-strategy prefetch" in args  # 17x load speedup
+        assert "--trust-remote-code" in args
+
+    def test_kimi_k2_6_serve_block(self, registry):
+        serve = registry["moonshotai/Kimi-K2.6"]["serve"]
+        assert serve["nodes"] == 4
+        assert serve["gpus_per_node"] == 8
+        args = " ".join(serve["vllm_args"])
+        assert "--enable-expert-parallel" in args
+        assert "--safetensors-load-strategy prefetch" in args
+        # Champion config explicitly does NOT use --enforce-eager (CUDA graphs
+        # give the dominant 4x throughput win on Kimi).
+        assert "--enforce-eager" not in args
+
+
+# ---------------------------------------------------------------------------
+# serve/resolve_serve_config.py — bridges models.yaml → serve.slurm shell vars
+# ---------------------------------------------------------------------------
+
+def _run_resolver(model: str) -> dict[str, str]:
+    """Invoke resolve_serve_config.py and parse its KEY=value output."""
+    result = subprocess.run(
+        [sys.executable, str(RESOLVE_SERVE_CONFIG), model],
+        capture_output=True, text=True, check=True,
+    )
+    out: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        if "=" not in line:
+            continue
+        k, v = line.split("=", 1)
+        # Strip the array-form wrapper for DEFAULT_VLLM_ARGS, leave others quoted.
+        if v.startswith("( ") and v.endswith(" )"):
+            out[k] = v[2:-2]
+        else:
+            out[k] = shlex.split(v)[0] if v else ""
+    return out
+
+
+class TestResolveServeConfig:
+    """resolve_serve_config.py emits the shell vars serve.slurm relies on. The
+    `DEFAULT_MODEL_ID` line is new in this PR (used to support alias keys)."""
+
+    def test_emits_all_required_shell_vars_for_kimi(self):
+        out = _run_resolver("moonshotai/Kimi-K2.6")
+        assert out["DEFAULT_MODEL_ID"] == "moonshotai/Kimi-K2.6"
+        assert out["DEFAULT_NODES"] == "4"
+        assert out["DEFAULT_GPUS_PER_NODE"] == "8"
+        assert "--enable-expert-parallel" in out["DEFAULT_VLLM_ARGS"]
+
+    def test_emits_all_required_shell_vars_for_glm(self):
+        out = _run_resolver("zai-org/GLM-5.1")
+        assert out["DEFAULT_MODEL_ID"] == "zai-org/GLM-5.1"
+        assert out["DEFAULT_NODES"] == "3"
+        assert out["DEFAULT_GPUS_PER_NODE"] == "8"
+        assert "--enforce-eager" in out["DEFAULT_VLLM_ARGS"]
+
+    def test_unknown_model_falls_back_to_input_as_model_id(self):
+        """No registry entry → DEFAULT_MODEL_ID == input model, no nodes/args."""
+        out = _run_resolver("not/a-real-model-key")
+        assert out["DEFAULT_MODEL_ID"] == "not/a-real-model-key"
+        assert out["DEFAULT_NODES"] == ""
+        assert out["DEFAULT_VLLM_ARGS"] == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_run_critpt_common.py
+++ b/tests/test_run_critpt_common.py
@@ -12,7 +12,10 @@ import pytest
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
 
-from run_critpt_common import RunResult, write_batch_metadata  # noqa: E402
+from run_critpt_common import (  # noqa: E402
+    RunResult, write_batch_metadata, write_initial_batch_metadata,
+    load_resume_config, find_completed_submissions,
+)
 
 
 def _call(output_dir: Path, results: list[RunResult], *,
@@ -190,6 +193,66 @@ def test_summary_arithmetic_matches_sum_over_attempts(tmp_path):
     assert s["total_cost_usd"] == pytest.approx(1.0)
     assert s["total_input_tokens"] == 2000 + 800 + 1500
     assert s["total_output_tokens"] == 500 + 200 + 300
+
+
+def _write_submission(output_dir: Path, n: int, *, with_code: bool = True) -> None:
+    """Write a CritPt-style submission JSON for problem ``n``."""
+    payload: dict = {"problem_id": f"Challenge_{n}_main"}
+    if with_code:
+        payload["generated_code"] = "x = 1"
+    (output_dir / f"Challenge_{n}_main.json").write_text(json.dumps(payload))
+
+
+def test_find_completed_submissions_returns_only_problems_with_code(tmp_path):
+    """A submission counts as complete iff it has both ``problem_id`` and ``generated_code``."""
+    _write_submission(tmp_path, 1)
+    _write_submission(tmp_path, 3)
+    _write_submission(tmp_path, 5, with_code=False)  # incomplete (no code)
+    (tmp_path / "Challenge_7_main.json").write_text("{not json")  # corrupt
+    (tmp_path / "logs").mkdir()  # ignored: not a submission
+    (tmp_path / "batch_metadata.json").write_text("{}")  # ignored: wrong name
+
+    assert find_completed_submissions(tmp_path) == {1, 3}
+
+
+def test_find_completed_submissions_empty_dir_returns_empty(tmp_path):
+    assert find_completed_submissions(tmp_path) == set()
+
+
+def test_load_resume_config_missing_metadata_exits_cleanly(tmp_path):
+    """The resume contract requires batch_metadata.json; missing → SystemExit, not crash."""
+    with pytest.raises(SystemExit) as exc_info:
+        load_resume_config(tmp_path)
+    assert exc_info.value.code == 1
+
+
+def test_initial_metadata_makes_killed_run_resumable(tmp_path):
+    """Initial stub is a valid resume target and merges cleanly with later results."""
+    write_initial_batch_metadata(
+        output_dir=tmp_path,
+        critpt_model="provider/model",
+        generation_config={"model_key": "mk"},
+        run_config={"timeout": 3600, "problems_subset": "1-3"},
+        start_time=T0,
+    )
+
+    # Stub must be loadable by the resume path even with zero completed problems.
+    gen_cfg, run_cfg = load_resume_config(tmp_path)
+    assert gen_cfg["model_key"] == "mk"
+    assert run_cfg["problems_subset"] == "1-3"
+
+    stub = json.loads((tmp_path / "batch_metadata.json").read_text())
+    assert stub["problems"] == []
+    assert stub["summary"]["this_run_total"] == 0
+    assert stub["summary"]["wall_clock_s"] == 0.0
+
+    # End-of-run write merges results into the stub without losing configs.
+    r = _r(5, success=True, duration_s=200.0,
+           stats={"cost_usd": 0.4, "input_tokens": 10000, "output_tokens": 2000})
+    final = _call(tmp_path, [r], start=T1, end=T1 + timedelta(seconds=210))
+    assert len(final["problems"]) == 1
+    assert final["problems"][0]["problem_id"] == "Challenge_5_main"
+    assert final["generation_config"]["model_key"] == "mk"
 
 
 def test_atomic_write_preserves_prior_on_replace_failure(tmp_path, monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -414,7 +414,7 @@ wheels = [
 
 [[package]]
 name = "compressed-tensors"
-version = "0.14.0.1"
+version = "0.15.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "loguru" },
@@ -422,9 +422,9 @@ dependencies = [
     { name = "torch" },
     { name = "transformers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/f1/4c9b01ceaf82ad58ad00919223e09b8e74d4073a2ba8e3ab2f97521ef65c/compressed_tensors-0.14.0.1.tar.gz", hash = "sha256:5ad3841184b6f5020e06059b2463191c5c57a144bb97cab9159978d8118839b1", size = 226393, upload-time = "2026-03-11T17:04:35.57Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/1b/c3c4a98ec5f2727656336f07a0c35862195c310d8eb0b2fa5b4be6848680/compressed_tensors-0.15.0.1.tar.gz", hash = "sha256:a8e93054e8a5ec49c980b09ed36c4c1249b4a8ee167920a8e461c4da26e78d99", size = 229412, upload-time = "2026-04-10T14:23:54.708Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0a/26/16a13993ecf4fdc9c39d63b3a6daabafd32a452cf68b81aa9eb3b8170913/compressed_tensors-0.14.0.1-py3-none-any.whl", hash = "sha256:46c4940a3a779d3d97108c294bfcd9acf4bd0491f7c6737c320f0e815ec732e4", size = 196454, upload-time = "2026-03-11T17:04:33.2Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/52/93833dc1610e017ac5b7dcd59b8304d8ef67d1114c2d124e728a2cbbea12/compressed_tensors-0.15.0.1-py3-none-any.whl", hash = "sha256:e1b1f322e82e475715e242bad46925a304ea8e5c98b5055a15b8eb22fb6bfea9", size = 194260, upload-time = "2026-04-10T14:23:53.098Z" },
 ]
 
 [[package]]
@@ -491,90 +491,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/93/8a/68a4ec5c55a2971213d29a9374913f7e9f18581945a7a31d1a39b5d2dfe5/contourpy-1.3.3-cp314-cp314t-win32.whl", hash = "sha256:e74a9a0f5e3fff48fb5a7f2fd2b9b70a3fe014a67522f79b7cca4c0c7e43c9ae", size = 202428, upload-time = "2025-07-26T12:02:48.691Z" },
     { url = "https://files.pythonhosted.org/packages/fa/96/fd9f641ffedc4fa3ace923af73b9d07e869496c9cc7a459103e6e978992f/contourpy-1.3.3-cp314-cp314t-win_amd64.whl", hash = "sha256:13b68d6a62db8eafaebb8039218921399baf6e47bf85006fd8529f2a08ef33fc", size = 250331, upload-time = "2025-07-26T12:02:50.137Z" },
     { url = "https://files.pythonhosted.org/packages/ae/8c/469afb6465b853afff216f9528ffda78a915ff880ed58813ba4faf4ba0b6/contourpy-1.3.3-cp314-cp314t-win_arm64.whl", hash = "sha256:b7448cb5a725bb1e35ce88771b86fba35ef418952474492cf7c764059933ff8b", size = 203831, upload-time = "2025-07-26T12:02:51.449Z" },
-]
-
-[[package]]
-name = "coverage"
-version = "7.13.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/24/56/95b7e30fa389756cb56630faa728da46a27b8c6eb46f9d557c68fff12b65/coverage-7.13.4.tar.gz", hash = "sha256:e5c8f6ed1e61a8b2dcdf31eb0b9bbf0130750ca79c1c49eb898e2ad86f5ccc91", size = 827239, upload-time = "2026-02-09T12:59:03.86Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/81/4ce2fdd909c5a0ed1f6dedb88aa57ab79b6d1fbd9b588c1ac7ef45659566/coverage-7.13.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:02231499b08dabbe2b96612993e5fc34217cdae907a51b906ac7fca8027a4459", size = 219449, upload-time = "2026-02-09T12:56:54.889Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/96/5238b1efc5922ddbdc9b0db9243152c09777804fb7c02ad1741eb18a11c0/coverage-7.13.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40aa8808140e55dc022b15d8aa7f651b6b3d68b365ea0398f1441e0b04d859c3", size = 219810, upload-time = "2026-02-09T12:56:56.33Z" },
-    { url = "https://files.pythonhosted.org/packages/78/72/2f372b726d433c9c35e56377cf1d513b4c16fe51841060d826b95caacec1/coverage-7.13.4-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5b856a8ccf749480024ff3bd7310adaef57bf31fd17e1bfc404b7940b6986634", size = 251308, upload-time = "2026-02-09T12:56:57.858Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/a0/2ea570925524ef4e00bb6c82649f5682a77fac5ab910a65c9284de422600/coverage-7.13.4-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2c048ea43875fbf8b45d476ad79f179809c590ec7b79e2035c662e7afa3192e3", size = 254052, upload-time = "2026-02-09T12:56:59.754Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/ac/45dc2e19a1939098d783c846e130b8f862fbb50d09e0af663988f2f21973/coverage-7.13.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b7b38448866e83176e28086674fe7368ab8590e4610fb662b44e345b86d63ffa", size = 255165, upload-time = "2026-02-09T12:57:01.287Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/4d/26d236ff35abc3b5e63540d3386e4c3b192168c1d96da5cb2f43c640970f/coverage-7.13.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:de6defc1c9badbf8b9e67ae90fd00519186d6ab64e5cc5f3d21359c2a9b2c1d3", size = 257432, upload-time = "2026-02-09T12:57:02.637Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/55/14a966c757d1348b2e19caf699415a2a4c4f7feaa4bbc6326a51f5c7dd1b/coverage-7.13.4-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7eda778067ad7ffccd23ecffce537dface96212576a07924cbf0d8799d2ded5a", size = 251716, upload-time = "2026-02-09T12:57:04.056Z" },
-    { url = "https://files.pythonhosted.org/packages/77/33/50116647905837c66d28b2af1321b845d5f5d19be9655cb84d4a0ea806b4/coverage-7.13.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e87f6c587c3f34356c3759f0420693e35e7eb0e2e41e4c011cb6ec6ecbbf1db7", size = 253089, upload-time = "2026-02-09T12:57:05.503Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/b4/8efb11a46e3665d92635a56e4f2d4529de6d33f2cb38afd47d779d15fc99/coverage-7.13.4-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:8248977c2e33aecb2ced42fef99f2d319e9904a36e55a8a68b69207fb7e43edc", size = 251232, upload-time = "2026-02-09T12:57:06.879Z" },
-    { url = "https://files.pythonhosted.org/packages/51/24/8cd73dd399b812cc76bb0ac260e671c4163093441847ffe058ac9fda1e32/coverage-7.13.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:25381386e80ae727608e662474db537d4df1ecd42379b5ba33c84633a2b36d47", size = 255299, upload-time = "2026-02-09T12:57:08.245Z" },
-    { url = "https://files.pythonhosted.org/packages/03/94/0a4b12f1d0e029ce1ccc1c800944a9984cbe7d678e470bb6d3c6bc38a0da/coverage-7.13.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:ee756f00726693e5ba94d6df2bdfd64d4852d23b09bb0bc700e3b30e6f333985", size = 250796, upload-time = "2026-02-09T12:57:10.142Z" },
-    { url = "https://files.pythonhosted.org/packages/73/44/6002fbf88f6698ca034360ce474c406be6d5a985b3fdb3401128031eef6b/coverage-7.13.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fdfc1e28e7c7cdce44985b3043bc13bbd9c747520f94a4d7164af8260b3d91f0", size = 252673, upload-time = "2026-02-09T12:57:12.197Z" },
-    { url = "https://files.pythonhosted.org/packages/de/c6/a0279f7c00e786be75a749a5674e6fa267bcbd8209cd10c9a450c655dfa7/coverage-7.13.4-cp312-cp312-win32.whl", hash = "sha256:01d4cbc3c283a17fc1e42d614a119f7f438eabb593391283adca8dc86eff1246", size = 221990, upload-time = "2026-02-09T12:57:14.085Z" },
-    { url = "https://files.pythonhosted.org/packages/77/4e/c0a25a425fcf5557d9abd18419c95b63922e897bc86c1f327f155ef234a9/coverage-7.13.4-cp312-cp312-win_amd64.whl", hash = "sha256:9401ebc7ef522f01d01d45532c68c5ac40fb27113019b6b7d8b208f6e9baa126", size = 222800, upload-time = "2026-02-09T12:57:15.944Z" },
-    { url = "https://files.pythonhosted.org/packages/47/ac/92da44ad9a6f4e3a7debd178949d6f3769bedca33830ce9b1dcdab589a37/coverage-7.13.4-cp312-cp312-win_arm64.whl", hash = "sha256:b1ec7b6b6e93255f952e27ab58fbc68dcc468844b16ecbee881aeb29b6ab4d8d", size = 221415, upload-time = "2026-02-09T12:57:17.497Z" },
-    { url = "https://files.pythonhosted.org/packages/db/23/aad45061a31677d68e47499197a131eea55da4875d16c1f42021ab963503/coverage-7.13.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b66a2da594b6068b48b2692f043f35d4d3693fb639d5ea8b39533c2ad9ac3ab9", size = 219474, upload-time = "2026-02-09T12:57:19.332Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/70/9b8b67a0945f3dfec1fd896c5cefb7c19d5a3a6d74630b99a895170999ae/coverage-7.13.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3599eb3992d814d23b35c536c28df1a882caa950f8f507cef23d1cbf334995ac", size = 219844, upload-time = "2026-02-09T12:57:20.66Z" },
-    { url = "https://files.pythonhosted.org/packages/97/fd/7e859f8fab324cef6c4ad7cff156ca7c489fef9179d5749b0c8d321281c2/coverage-7.13.4-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:93550784d9281e374fb5a12bf1324cc8a963fd63b2d2f223503ef0fd4aa339ea", size = 250832, upload-time = "2026-02-09T12:57:22.007Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/dc/b2442d10020c2f52617828862d8b6ee337859cd8f3a1f13d607dddda9cf7/coverage-7.13.4-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b720ce6a88a2755f7c697c23268ddc47a571b88052e6b155224347389fdf6a3b", size = 253434, upload-time = "2026-02-09T12:57:23.339Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/88/6728a7ad17428b18d836540630487231f5470fb82454871149502f5e5aa2/coverage-7.13.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7b322db1284a2ed3aa28ffd8ebe3db91c929b7a333c0820abec3d838ef5b3525", size = 254676, upload-time = "2026-02-09T12:57:24.774Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/bc/21244b1b8cedf0dff0a2b53b208015fe798d5f2a8d5348dbfece04224fff/coverage-7.13.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f4594c67d8a7c89cf922d9df0438c7c7bb022ad506eddb0fdb2863359ff78242", size = 256807, upload-time = "2026-02-09T12:57:26.125Z" },
-    { url = "https://files.pythonhosted.org/packages/97/a0/ddba7ed3251cff51006737a727d84e05b61517d1784a9988a846ba508877/coverage-7.13.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:53d133df809c743eb8bce33b24bcababb371f4441340578cd406e084d94a6148", size = 251058, upload-time = "2026-02-09T12:57:27.614Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/55/e289addf7ff54d3a540526f33751951bf0878f3809b47f6dfb3def69c6f7/coverage-7.13.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:76451d1978b95ba6507a039090ba076105c87cc76fc3efd5d35d72093964d49a", size = 252805, upload-time = "2026-02-09T12:57:29.066Z" },
-    { url = "https://files.pythonhosted.org/packages/13/4e/cc276b1fa4a59be56d96f1dabddbdc30f4ba22e3b1cd42504c37b3313255/coverage-7.13.4-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:7f57b33491e281e962021de110b451ab8a24182589be17e12a22c79047935e23", size = 250766, upload-time = "2026-02-09T12:57:30.522Z" },
-    { url = "https://files.pythonhosted.org/packages/94/44/1093b8f93018f8b41a8cf29636c9292502f05e4a113d4d107d14a3acd044/coverage-7.13.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:1731dc33dc276dafc410a885cbf5992f1ff171393e48a21453b78727d090de80", size = 254923, upload-time = "2026-02-09T12:57:31.946Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/55/ea2796da2d42257f37dbea1aab239ba9263b31bd91d5527cdd6db5efe174/coverage-7.13.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:bd60d4fe2f6fa7dff9223ca1bbc9f05d2b6697bc5961072e5d3b952d46e1b1ea", size = 250591, upload-time = "2026-02-09T12:57:33.842Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/fa/7c4bb72aacf8af5020675aa633e59c1fbe296d22aed191b6a5b711eb2bc7/coverage-7.13.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9181a3ccead280b828fae232df12b16652702b49d41e99d657f46cc7b1f6ec7a", size = 252364, upload-time = "2026-02-09T12:57:35.743Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/38/a8d2ec0146479c20bbaa7181b5b455a0c41101eed57f10dd19a78ab44c80/coverage-7.13.4-cp313-cp313-win32.whl", hash = "sha256:f53d492307962561ac7de4cd1de3e363589b000ab69617c6156a16ba7237998d", size = 222010, upload-time = "2026-02-09T12:57:37.25Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/0c/dbfafbe90a185943dcfbc766fe0e1909f658811492d79b741523a414a6cc/coverage-7.13.4-cp313-cp313-win_amd64.whl", hash = "sha256:e6f70dec1cc557e52df5306d051ef56003f74d56e9c4dd7ddb07e07ef32a84dd", size = 222818, upload-time = "2026-02-09T12:57:38.734Z" },
-    { url = "https://files.pythonhosted.org/packages/04/d1/934918a138c932c90d78301f45f677fb05c39a3112b96fd2c8e60503cdc7/coverage-7.13.4-cp313-cp313-win_arm64.whl", hash = "sha256:fb07dc5da7e849e2ad31a5d74e9bece81f30ecf5a42909d0a695f8bd1874d6af", size = 221438, upload-time = "2026-02-09T12:57:40.223Z" },
-    { url = "https://files.pythonhosted.org/packages/52/57/ee93ced533bcb3e6df961c0c6e42da2fc6addae53fb95b94a89b1e33ebd7/coverage-7.13.4-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:40d74da8e6c4b9ac18b15331c4b5ebc35a17069410cad462ad4f40dcd2d50c0d", size = 220165, upload-time = "2026-02-09T12:57:41.639Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/e0/969fc285a6fbdda49d91af278488d904dcd7651b2693872f0ff94e40e84a/coverage-7.13.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4223b4230a376138939a9173f1bdd6521994f2aff8047fae100d6d94d50c5a12", size = 220516, upload-time = "2026-02-09T12:57:44.215Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/b8/9531944e16267e2735a30a9641ff49671f07e8138ecf1ca13db9fd2560c7/coverage-7.13.4-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:1d4be36a5114c499f9f1f9195e95ebf979460dbe2d88e6816ea202010ba1c34b", size = 261804, upload-time = "2026-02-09T12:57:45.989Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/f3/e63df6d500314a2a60390d1989240d5f27318a7a68fa30ad3806e2a9323e/coverage-7.13.4-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:200dea7d1e8095cc6e98cdabe3fd1d21ab17d3cee6dab00cadbb2fe35d9c15b9", size = 263885, upload-time = "2026-02-09T12:57:47.42Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/67/7654810de580e14b37670b60a09c599fa348e48312db5b216d730857ffe6/coverage-7.13.4-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b8eb931ee8e6d8243e253e5ed7336deea6904369d2fd8ae6e43f68abbf167092", size = 266308, upload-time = "2026-02-09T12:57:49.345Z" },
-    { url = "https://files.pythonhosted.org/packages/37/6f/39d41eca0eab3cc82115953ad41c4e77935286c930e8fad15eaed1389d83/coverage-7.13.4-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:75eab1ebe4f2f64d9509b984f9314d4aa788540368218b858dad56dc8f3e5eb9", size = 267452, upload-time = "2026-02-09T12:57:50.811Z" },
-    { url = "https://files.pythonhosted.org/packages/50/6d/39c0fbb8fc5cd4d2090811e553c2108cf5112e882f82505ee7495349a6bf/coverage-7.13.4-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c35eb28c1d085eb7d8c9b3296567a1bebe03ce72962e932431b9a61f28facf26", size = 261057, upload-time = "2026-02-09T12:57:52.447Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/a2/60010c669df5fa603bb5a97fb75407e191a846510da70ac657eb696b7fce/coverage-7.13.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:eb88b316ec33760714a4720feb2816a3a59180fd58c1985012054fa7aebee4c2", size = 263875, upload-time = "2026-02-09T12:57:53.938Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/d9/63b22a6bdbd17f1f96e9ed58604c2a6b0e72a9133e37d663bef185877cf6/coverage-7.13.4-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:7d41eead3cc673cbd38a4417deb7fd0b4ca26954ff7dc6078e33f6ff97bed940", size = 261500, upload-time = "2026-02-09T12:57:56.012Z" },
-    { url = "https://files.pythonhosted.org/packages/70/bf/69f86ba1ad85bc3ad240e4c0e57a2e620fbc0e1645a47b5c62f0e941ad7f/coverage-7.13.4-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:fb26a934946a6afe0e326aebe0730cdff393a8bc0bbb65a2f41e30feddca399c", size = 265212, upload-time = "2026-02-09T12:57:57.5Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/f2/5f65a278a8c2148731831574c73e42f57204243d33bedaaf18fa79c5958f/coverage-7.13.4-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:dae88bc0fc77edaa65c14be099bd57ee140cf507e6bfdeea7938457ab387efb0", size = 260398, upload-time = "2026-02-09T12:57:59.027Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/80/6e8280a350ee9fea92f14b8357448a242dcaa243cb2c72ab0ca591f66c8c/coverage-7.13.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:845f352911777a8e722bfce168958214951e07e47e5d5d9744109fa5fe77f79b", size = 262584, upload-time = "2026-02-09T12:58:01.129Z" },
-    { url = "https://files.pythonhosted.org/packages/22/63/01ff182fc95f260b539590fb12c11ad3e21332c15f9799cb5e2386f71d9f/coverage-7.13.4-cp313-cp313t-win32.whl", hash = "sha256:2fa8d5f8de70688a28240de9e139fa16b153cc3cbb01c5f16d88d6505ebdadf9", size = 222688, upload-time = "2026-02-09T12:58:02.736Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/43/89de4ef5d3cd53b886afa114065f7e9d3707bdb3e5efae13535b46ae483d/coverage-7.13.4-cp313-cp313t-win_amd64.whl", hash = "sha256:9351229c8c8407645840edcc277f4a2d44814d1bc34a2128c11c2a031d45a5dd", size = 223746, upload-time = "2026-02-09T12:58:05.362Z" },
-    { url = "https://files.pythonhosted.org/packages/35/39/7cf0aa9a10d470a5309b38b289b9bb07ddeac5d61af9b664fe9775a4cb3e/coverage-7.13.4-cp313-cp313t-win_arm64.whl", hash = "sha256:30b8d0512f2dc8c8747557e8fb459d6176a2c9e5731e2b74d311c03b78451997", size = 222003, upload-time = "2026-02-09T12:58:06.952Z" },
-    { url = "https://files.pythonhosted.org/packages/92/11/a9cf762bb83386467737d32187756a42094927150c3e107df4cb078e8590/coverage-7.13.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:300deaee342f90696ed186e3a00c71b5b3d27bffe9e827677954f4ee56969601", size = 219522, upload-time = "2026-02-09T12:58:08.623Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/28/56e6d892b7b052236d67c95f1936b6a7cf7c3e2634bf27610b8cbd7f9c60/coverage-7.13.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:29e3220258d682b6226a9b0925bc563ed9a1ebcff3cad30f043eceea7eaf2689", size = 219855, upload-time = "2026-02-09T12:58:10.176Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/69/233459ee9eb0c0d10fcc2fe425a029b3fa5ce0f040c966ebce851d030c70/coverage-7.13.4-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:391ee8f19bef69210978363ca930f7328081c6a0152f1166c91f0b5fdd2a773c", size = 250887, upload-time = "2026-02-09T12:58:12.503Z" },
-    { url = "https://files.pythonhosted.org/packages/06/90/2cdab0974b9b5bbc1623f7876b73603aecac11b8d95b85b5b86b32de5eab/coverage-7.13.4-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0dd7ab8278f0d58a0128ba2fca25824321f05d059c1441800e934ff2efa52129", size = 253396, upload-time = "2026-02-09T12:58:14.615Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/15/ea4da0f85bf7d7b27635039e649e99deb8173fe551096ea15017f7053537/coverage-7.13.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:78cdf0d578b15148b009ccf18c686aa4f719d887e76e6b40c38ffb61d264a552", size = 254745, upload-time = "2026-02-09T12:58:16.162Z" },
-    { url = "https://files.pythonhosted.org/packages/99/11/bb356e86920c655ca4d61daee4e2bbc7258f0a37de0be32d233b561134ff/coverage-7.13.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:48685fee12c2eb3b27c62f2658e7ea21e9c3239cba5a8a242801a0a3f6a8c62a", size = 257055, upload-time = "2026-02-09T12:58:17.892Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/0f/9ae1f8cb17029e09da06ca4e28c9e1d5c1c0a511c7074592e37e0836c915/coverage-7.13.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4e83efc079eb39480e6346a15a1bcb3e9b04759c5202d157e1dd4303cd619356", size = 250911, upload-time = "2026-02-09T12:58:19.495Z" },
-    { url = "https://files.pythonhosted.org/packages/89/3a/adfb68558fa815cbc29747b553bc833d2150228f251b127f1ce97e48547c/coverage-7.13.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ecae9737b72408d6a950f7e525f30aca12d4bd8dd95e37342e5beb3a2a8c4f71", size = 252754, upload-time = "2026-02-09T12:58:21.064Z" },
-    { url = "https://files.pythonhosted.org/packages/32/b1/540d0c27c4e748bd3cd0bd001076ee416eda993c2bae47a73b7cc9357931/coverage-7.13.4-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ae4578f8528569d3cf303fef2ea569c7f4c4059a38c8667ccef15c6e1f118aa5", size = 250720, upload-time = "2026-02-09T12:58:22.622Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/95/383609462b3ffb1fe133014a7c84fc0dd01ed55ac6140fa1093b5af7ebb1/coverage-7.13.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:6fdef321fdfbb30a197efa02d48fcd9981f0d8ad2ae8903ac318adc653f5df98", size = 254994, upload-time = "2026-02-09T12:58:24.548Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/ba/1761138e86c81680bfc3c49579d66312865457f9fe405b033184e5793cb3/coverage-7.13.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2b0f6ccf3dbe577170bebfce1318707d0e8c3650003cb4b3a9dd744575daa8b5", size = 250531, upload-time = "2026-02-09T12:58:26.271Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/8e/05900df797a9c11837ab59c4d6fe94094e029582aab75c3309a93e6fb4e3/coverage-7.13.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:75fcd519f2a5765db3f0e391eb3b7d150cce1a771bf4c9f861aeab86c767a3c0", size = 252189, upload-time = "2026-02-09T12:58:27.807Z" },
-    { url = "https://files.pythonhosted.org/packages/00/bd/29c9f2db9ea4ed2738b8a9508c35626eb205d51af4ab7bf56a21a2e49926/coverage-7.13.4-cp314-cp314-win32.whl", hash = "sha256:8e798c266c378da2bd819b0677df41ab46d78065fb2a399558f3f6cae78b2fbb", size = 222258, upload-time = "2026-02-09T12:58:29.441Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/4d/1f8e723f6829977410efeb88f73673d794075091c8c7c18848d273dc9d73/coverage-7.13.4-cp314-cp314-win_amd64.whl", hash = "sha256:245e37f664d89861cf2329c9afa2c1fe9e6d4e1a09d872c947e70718aeeac505", size = 223073, upload-time = "2026-02-09T12:58:31.026Z" },
-    { url = "https://files.pythonhosted.org/packages/51/5b/84100025be913b44e082ea32abcf1afbf4e872f5120b7a1cab1d331b1e13/coverage-7.13.4-cp314-cp314-win_arm64.whl", hash = "sha256:ad27098a189e5838900ce4c2a99f2fe42a0bf0c2093c17c69b45a71579e8d4a2", size = 221638, upload-time = "2026-02-09T12:58:32.599Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/e4/c884a405d6ead1370433dad1e3720216b4f9fd8ef5b64bfd984a2a60a11a/coverage-7.13.4-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:85480adfb35ffc32d40918aad81b89c69c9cc5661a9b8a81476d3e645321a056", size = 220246, upload-time = "2026-02-09T12:58:34.181Z" },
-    { url = "https://files.pythonhosted.org/packages/81/5c/4d7ed8b23b233b0fffbc9dfec53c232be2e695468523242ea9fd30f97ad2/coverage-7.13.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:79be69cf7f3bf9b0deeeb062eab7ac7f36cd4cc4c4dd694bd28921ba4d8596cc", size = 220514, upload-time = "2026-02-09T12:58:35.704Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/6f/3284d4203fd2f28edd73034968398cd2d4cb04ab192abc8cff007ea35679/coverage-7.13.4-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:caa421e2684e382c5d8973ac55e4f36bed6821a9bad5c953494de960c74595c9", size = 261877, upload-time = "2026-02-09T12:58:37.864Z" },
-    { url = "https://files.pythonhosted.org/packages/09/aa/b672a647bbe1556a85337dc95bfd40d146e9965ead9cc2fe81bde1e5cbce/coverage-7.13.4-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14375934243ee05f56c45393fe2ce81fe5cc503c07cee2bdf1725fb8bef3ffaf", size = 264004, upload-time = "2026-02-09T12:58:39.492Z" },
-    { url = "https://files.pythonhosted.org/packages/79/a1/aa384dbe9181f98bba87dd23dda436f0c6cf2e148aecbb4e50fc51c1a656/coverage-7.13.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:25a41c3104d08edb094d9db0d905ca54d0cd41c928bb6be3c4c799a54753af55", size = 266408, upload-time = "2026-02-09T12:58:41.852Z" },
-    { url = "https://files.pythonhosted.org/packages/53/5e/5150bf17b4019bc600799f376bb9606941e55bd5a775dc1e096b6ffea952/coverage-7.13.4-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f01afcff62bf9a08fb32b2c1d6e924236c0383c02c790732b6537269e466a72", size = 267544, upload-time = "2026-02-09T12:58:44.093Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/ed/f1de5c675987a4a7a672250d2c5c9d73d289dbf13410f00ed7181d8017dd/coverage-7.13.4-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:eb9078108fbf0bcdde37c3f4779303673c2fa1fe8f7956e68d447d0dd426d38a", size = 260980, upload-time = "2026-02-09T12:58:45.721Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/e3/fe758d01850aa172419a6743fe76ba8b92c29d181d4f676ffe2dae2ba631/coverage-7.13.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0e086334e8537ddd17e5f16a344777c1ab8194986ec533711cbe6c41cde841b6", size = 263871, upload-time = "2026-02-09T12:58:47.334Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/76/b829869d464115e22499541def9796b25312b8cf235d3bb00b39f1675395/coverage-7.13.4-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:725d985c5ab621268b2edb8e50dfe57633dc69bda071abc470fed55a14935fd3", size = 261472, upload-time = "2026-02-09T12:58:48.995Z" },
-    { url = "https://files.pythonhosted.org/packages/14/9e/caedb1679e73e2f6ad240173f55218488bfe043e38da577c4ec977489915/coverage-7.13.4-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:3c06f0f1337c667b971ca2f975523347e63ec5e500b9aa5882d91931cd3ef750", size = 265210, upload-time = "2026-02-09T12:58:51.178Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/10/0dd02cb009b16ede425b49ec344aba13a6ae1dc39600840ea6abcb085ac4/coverage-7.13.4-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:590c0ed4bf8e85f745e6b805b2e1c457b2e33d5255dd9729743165253bc9ad39", size = 260319, upload-time = "2026-02-09T12:58:53.081Z" },
-    { url = "https://files.pythonhosted.org/packages/92/8e/234d2c927af27c6d7a5ffad5bd2cf31634c46a477b4c7adfbfa66baf7ebb/coverage-7.13.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:eb30bf180de3f632cd043322dad5751390e5385108b2807368997d1a92a509d0", size = 262638, upload-time = "2026-02-09T12:58:55.258Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/64/e5547c8ff6964e5965c35a480855911b61509cce544f4d442caa759a0702/coverage-7.13.4-cp314-cp314t-win32.whl", hash = "sha256:c4240e7eded42d131a2d2c4dec70374b781b043ddc79a9de4d55ca71f8e98aea", size = 223040, upload-time = "2026-02-09T12:58:56.936Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/96/38086d58a181aac86d503dfa9c47eb20715a79c3e3acbdf786e92e5c09a8/coverage-7.13.4-cp314-cp314t-win_amd64.whl", hash = "sha256:4c7d3cc01e7350f2f0f6f7036caaf5673fb56b6998889ccfe9e1c1fe75a9c932", size = 224148, upload-time = "2026-02-09T12:58:58.645Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/72/8d10abd3740a0beb98c305e0c3faf454366221c0f37a8bcf8f60020bb65a/coverage-7.13.4-cp314-cp314t-win_arm64.whl", hash = "sha256:23e3f687cf945070d1c90f85db66d11e3025665d8dafa831301a0e0038f3db9b", size = 222172, upload-time = "2026-02-09T12:59:00.396Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/4a/331fe2caf6799d591109bb9c08083080f6de90a823695d412a935622abb2/coverage-7.13.4-py3-none-any.whl", hash = "sha256:1af1641e57cf7ba1bd67d677c9abdbcd6cc2ab7da3bca7fa1e2b7e50e65f2ad0", size = 211242, upload-time = "2026-02-09T12:59:02.032Z" },
 ]
 
 [[package]]
@@ -676,6 +592,14 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a9/95/a3dbbb5028f35eafb79008e7522a75244477d2838f38cbb722248dabc2a8/cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c", size = 7615, upload-time = "2023-10-07T05:32:18.335Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30", size = 8321, upload-time = "2023-10-07T05:32:16.783Z" },
+]
+
+[[package]]
+name = "deep-gemm"
+version = "2.3.0+477618c"
+source = { path = "deep_gemm-2.3.0+477618c-cp313-cp313-linux_x86_64.whl" }
+wheels = [
+    { filename = "deep_gemm-2.3.0+477618c-cp313-cp313-linux_x86_64.whl", hash = "sha256:1c0ba6bb8ab9711f2c699adc615d8d2d97ffc77c03e62cc5b0182b8832944502" },
 ]
 
 [[package]]
@@ -1163,34 +1087,34 @@ wheels = [
 
 [[package]]
 name = "hf-xet"
-version = "1.4.0"
+version = "1.4.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/68/01/928fd82663fb0ab455551a178303a2960e65029da66b21974594f3a20a94/hf_xet-1.4.0.tar.gz", hash = "sha256:48e6ba7422b0885c9bbd8ac8fdf5c4e1306c3499b82d489944609cc4eae8ecbd", size = 660350, upload-time = "2026-03-11T18:50:03.354Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/92/ec9ad04d0b5728dca387a45af7bc98fbb0d73b2118759f5f6038b61a57e8/hf_xet-1.4.3.tar.gz", hash = "sha256:8ddedb73c8c08928c793df2f3401ec26f95be7f7e516a7bee2fbb546f6676113", size = 670477, upload-time = "2026-03-31T22:40:07.874Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/4b/2351e30dddc6f3b47b3da0a0693ec1e82f8303b1a712faa299cf3552002b/hf_xet-1.4.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:76725fcbc5f59b23ac778f097d3029d6623e3cf6f4057d99d1fce1a7e3cff8fc", size = 3796397, upload-time = "2026-03-11T18:49:47.382Z" },
-    { url = "https://files.pythonhosted.org/packages/48/3d/3db90ec0afb4e26e3330b1346b89fe0e9a3b7bfc2d6a2b2262787790d25f/hf_xet-1.4.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:76f1f73bee81a6e6f608b583908aa24c50004965358ac92c1dc01080a21bcd09", size = 3556235, upload-time = "2026-03-11T18:49:45.785Z" },
-    { url = "https://files.pythonhosted.org/packages/57/6e/2a662af2cbc6c0a64ebe9fcdb8faf05b5205753d45a75a3011bb2209d0b4/hf_xet-1.4.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1818c2e5d6f15354c595d5111c6eb0e5a30a6c5c1a43eeaec20f19607cff0b34", size = 4213145, upload-time = "2026-03-11T18:49:38.009Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/4a/47c129affb540767e0e3e101039a95f4a73a292ec689c26e8f0c5b633f9d/hf_xet-1.4.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:70764d295f485db9cc9a6af76634ea00ec4f96311be7485f8f2b6144739b4ccf", size = 3991951, upload-time = "2026-03-11T18:49:36.396Z" },
-    { url = "https://files.pythonhosted.org/packages/76/81/ec516cfc6281cfeef027b0919166b2fe11ab61fbe6131a2c43fafbed8b68/hf_xet-1.4.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9d3bd2a1e289f772c715ca88cdca8ceb3d8b5c9186534d5925410e531d849a3e", size = 4193205, upload-time = "2026-03-11T18:49:54.415Z" },
-    { url = "https://files.pythonhosted.org/packages/49/48/0945b5e542ed6c6ce758b589b27895a449deab630dfcdee5a6ee0f699d21/hf_xet-1.4.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:06da3797f1fdd9a8f8dbc8c1bddfa0b914789b14580c375d29c32ee35c2c66ca", size = 4431022, upload-time = "2026-03-11T18:49:55.677Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/ad/a4859c55ab4b67a4fde2849be8bde81917f54062050419b821071f199a9c/hf_xet-1.4.0-cp313-cp313t-win_amd64.whl", hash = "sha256:30b9d8f384ccec848124d51d883e91f3c88d430589e02a7b6d867730ab8d53ac", size = 3674977, upload-time = "2026-03-11T18:50:06.369Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/17/5bf3791e3a53e597913c2a775a48a98aaded9c2ddb5d1afaedabb55e2ed8/hf_xet-1.4.0-cp313-cp313t-win_arm64.whl", hash = "sha256:07ffdbf7568fa3245b24d949f0f3790b5276fb7293a5554ac4ec02e5f7e2b38d", size = 3536778, upload-time = "2026-03-11T18:50:04.974Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/a1/05a7f9d6069bf78405d3fc2464b6c76b167128501e13b4f1d6266e1d1f54/hf_xet-1.4.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:e2731044f3a18442f9f7a3dcf03b96af13dee311f03846a1df1f0553a3ea0fc6", size = 3796727, upload-time = "2026-03-11T18:49:52.889Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/8a/67abc642c2b32efcb7a257cdad8555c2904e23f18a1b4fec3aef1ebfe0fc/hf_xet-1.4.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b6f3729335fbc4baef60fe14fe32ef13ac9d377bdc898148c541e20c6056b504", size = 3555869, upload-time = "2026-03-11T18:49:51.313Z" },
-    { url = "https://files.pythonhosted.org/packages/19/3d/4765367c64ee70db15fa771d5b94bf12540b85076a1d3210ebbfec42d477/hf_xet-1.4.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9c0c9f052738a024073d332c573275c8e33697a3ef3f5dd2fb4ef98216e1e74a", size = 4212980, upload-time = "2026-03-11T18:49:44.21Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/bf/6ad99ee0e7ca2318f912a87318e493d82d8f9aace6be81f774bd14b996df/hf_xet-1.4.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:f44b2324be75bfa399735996ac299fd478684c48ce47d12a42b5f24b1a99ccb8", size = 3991136, upload-time = "2026-03-11T18:49:42.512Z" },
-    { url = "https://files.pythonhosted.org/packages/50/aa/932e25c69699076088f57e3c14f83ccae87bac25e755994f3362acc908d5/hf_xet-1.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:01de78b1ceddf8b38da001f7cc728b3bc3eb956948b18e8a1997ad6fc80fbe9d", size = 4192676, upload-time = "2026-03-11T18:50:00.216Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/0a/5e41339a294fd3450948989a47ecba9824d5bc1950cf767f928ecaf53a55/hf_xet-1.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cac8616e7a974105c3494735313f5ab0fb79b5accadec1a7a992859a15536a9", size = 4430729, upload-time = "2026-03-11T18:50:01.923Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/c1/c3d8ed9b7118e9166b0cf71dfd501da82f1abe306387e34e0f3ee59553ec/hf_xet-1.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:3a5d9cb25095ceb3beab4843ae2d1b3e5746371ddbf2e5849f7be6a7d6f44df4", size = 3674989, upload-time = "2026-03-11T18:50:12.633Z" },
-    { url = "https://files.pythonhosted.org/packages/65/bc/ea26cf774063cb09d7aaaa6cba9d341fb72b42ea99b8a94ca254dbafbbb0/hf_xet-1.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:9b777674499dc037317db372c90a2dd91329b5f1ee93c645bb89155bb974f5bf", size = 3536805, upload-time = "2026-03-11T18:50:11.082Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/f9/a0b01945726aea81d2f213457cd5f5102a51e6fd1ca9f9769f561fb57501/hf_xet-1.4.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:981d2b5222c3baadf9567c135cf1d1073786f546b7745686978d46b5df179e16", size = 3799223, upload-time = "2026-03-11T18:49:49.884Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/30/ee62b0c00412f49a7e6f509f0104ee8808692278d247234336df48029349/hf_xet-1.4.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:cc8bd050349d0d7995ce7b3a3a18732a2a8062ce118a82431602088abb373428", size = 3560682, upload-time = "2026-03-11T18:49:48.633Z" },
-    { url = "https://files.pythonhosted.org/packages/93/d0/0fe5c44dbced465a651a03212e1135d0d7f95d19faada692920cb56f8e38/hf_xet-1.4.0-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5d0c38d2a280d814280b8c15eead4a43c9781e7bf6fc37843cffab06dcdc76b9", size = 4218323, upload-time = "2026-03-11T18:49:40.921Z" },
-    { url = "https://files.pythonhosted.org/packages/73/df/7b3c99a4e50442039eae498e5c23db634538eb3e02214109880cf1165d4c/hf_xet-1.4.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:6a883f0250682ea888a1bd0af0631feda377e59ad7aae6fb75860ecee7ae0f93", size = 3997156, upload-time = "2026-03-11T18:49:39.634Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/26/47dfedf271c21d95346660ae1698e7ece5ab10791fa6c4f20c59f3713083/hf_xet-1.4.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:99e1d9255fe8ecdf57149bb0543d49e7b7bd8d491ddf431eb57e114253274df5", size = 4199052, upload-time = "2026-03-11T18:49:57.097Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/c0/346b9aad1474e881e65f998d5c1981695f0af045bc7a99204d9d86759a89/hf_xet-1.4.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b25f06ce42bd2d5f2e79d4a2d72f783d3ac91827c80d34a38cf8e5290dd717b0", size = 4434346, upload-time = "2026-03-11T18:49:58.67Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/d6/88ce9d6caa397c3b935263d5bcbe3ebf6c443f7c76098b8c523d206116b9/hf_xet-1.4.0-cp37-abi3-win_amd64.whl", hash = "sha256:8d6d7816d01e0fa33f315c8ca21b05eca0ce4cdc314f13b81d953e46cc6db11d", size = 3678921, upload-time = "2026-03-11T18:50:09.496Z" },
-    { url = "https://files.pythonhosted.org/packages/65/eb/17d99ed253b28a9550ca479867c66a8af4c9bcd8cdc9a26b0c8007c2000a/hf_xet-1.4.0-cp37-abi3-win_arm64.whl", hash = "sha256:cb8d9549122b5b42f34b23b14c6b662a88a586a919d418c774d8dbbc4b3ce2aa", size = 3541054, upload-time = "2026-03-11T18:50:07.963Z" },
+    { url = "https://files.pythonhosted.org/packages/72/43/724d307b34e353da0abd476e02f72f735cdd2bc86082dee1b32ea0bfee1d/hf_xet-1.4.3-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:7551659ba4f1e1074e9623996f28c3873682530aee0a846b7f2f066239228144", size = 3800935, upload-time = "2026-03-31T22:39:49.618Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/d2/8bee5996b699262edb87dbb54118d287c0e1b2fc78af7cdc41857ba5e3c4/hf_xet-1.4.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:bee693ada985e7045997f05f081d0e12c4c08bd7626dc397f8a7c487e6c04f7f", size = 3558942, upload-time = "2026-03-31T22:39:47.938Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/a1/e993d09cbe251196fb60812b09a58901c468127b7259d2bf0f68bf6088eb/hf_xet-1.4.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:21644b404bb0100fe3857892f752c4d09642586fd988e61501c95bbf44b393a3", size = 4207657, upload-time = "2026-03-31T22:39:39.69Z" },
+    { url = "https://files.pythonhosted.org/packages/64/44/9eb6d21e5c34c63e5e399803a6932fa983cabdf47c0ecbcfe7ea97684b8c/hf_xet-1.4.3-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:987f09cfe418237812896a6736b81b1af02a3a6dcb4b4944425c4c4fca7a7cf8", size = 3986765, upload-time = "2026-03-31T22:39:37.936Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/7b/8ad6f16fdb82f5f7284a34b5ec48645bd575bdcd2f6f0d1644775909c486/hf_xet-1.4.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:60cf7fc43a99da0a853345cf86d23738c03983ee5249613a6305d3e57a5dca74", size = 4188162, upload-time = "2026-03-31T22:39:58.382Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/c4/39d6e136cbeea9ca5a23aad4b33024319222adbdc059ebcda5fc7d9d5ff4/hf_xet-1.4.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2815a49a7a59f3e2edf0cf113ae88e8cb2ca2a221bf353fb60c609584f4884d4", size = 4424525, upload-time = "2026-03-31T22:40:00.225Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f2/adc32dae6bdbc367853118b9878139ac869419a4ae7ba07185dc31251b76/hf_xet-1.4.3-cp313-cp313t-win_amd64.whl", hash = "sha256:42ee323265f1e6a81b0e11094564fb7f7e0ec75b5105ffd91ae63f403a11931b", size = 3671610, upload-time = "2026-03-31T22:40:10.42Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/19/25d897dcc3f81953e0c2cde9ec186c7a0fee413eb0c9a7a9130d87d94d3a/hf_xet-1.4.3-cp313-cp313t-win_arm64.whl", hash = "sha256:27c976ba60079fb8217f485b9c5c7fcd21c90b0367753805f87cb9f3cdc4418a", size = 3528529, upload-time = "2026-03-31T22:40:09.106Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/36/3e8f85ca9fe09b8de2b2e10c63b3b3353d7dda88a0b3d426dffbe7b8313b/hf_xet-1.4.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:5251d5ece3a81815bae9abab41cf7ddb7bcb8f56411bce0827f4a3071c92fdc6", size = 3801019, upload-time = "2026-03-31T22:39:56.651Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/9c/defb6cb1de28bccb7bd8d95f6e60f72a3d3fa4cb3d0329c26fb9a488bfe7/hf_xet-1.4.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1feb0f3abeacee143367c326a128a2e2b60868ec12a36c225afb1d6c5a05e6d2", size = 3558746, upload-time = "2026-03-31T22:39:54.766Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/bd/8d001191893178ff8e826e46ad5299446e62b93cd164e17b0ffea08832ec/hf_xet-1.4.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8b301fc150290ca90b4fccd079829b84bb4786747584ae08b94b4577d82fb791", size = 4207692, upload-time = "2026-03-31T22:39:46.246Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/6790b402803250e9936435613d3a78b9aaeee7973439f0918848dde58309/hf_xet-1.4.3-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:d972fbe95ddc0d3c0fc49b31a8a69f47db35c1e3699bf316421705741aab6653", size = 3986281, upload-time = "2026-03-31T22:39:44.648Z" },
+    { url = "https://files.pythonhosted.org/packages/51/56/ea62552fe53db652a9099eda600b032d75554d0e86c12a73824bfedef88b/hf_xet-1.4.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c5b48db1ee344a805a1b9bd2cda9b6b65fe77ed3787bd6e87ad5521141d317cd", size = 4187414, upload-time = "2026-03-31T22:40:04.951Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/f5/bc1456d4638061bea997e6d2db60a1a613d7b200e0755965ec312dc1ef79/hf_xet-1.4.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:22bdc1f5fb8b15bf2831440b91d1c9bbceeb7e10c81a12e8d75889996a5c9da8", size = 4424368, upload-time = "2026-03-31T22:40:06.347Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/76/ab597bae87e1f06d18d3ecb8ed7f0d3c9a37037fc32ce76233d369273c64/hf_xet-1.4.3-cp314-cp314t-win_amd64.whl", hash = "sha256:0392c79b7cf48418cd61478c1a925246cf10639f4cd9d94368d8ca1e8df9ea07", size = 3672280, upload-time = "2026-03-31T22:40:16.401Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/2e462d34e23a09a74d73785dbed71cc5dbad82a72eee2ad60a72a554155d/hf_xet-1.4.3-cp314-cp314t-win_arm64.whl", hash = "sha256:681c92a07796325778a79d76c67011764ecc9042a8c3579332b61b63ae512075", size = 3528945, upload-time = "2026-03-31T22:40:14.995Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/9f/9c23e4a447b8f83120798f9279d0297a4d1360bdbf59ef49ebec78fe2545/hf_xet-1.4.3-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:d0da85329eaf196e03e90b84c2d0aca53bd4573d097a75f99609e80775f98025", size = 3805048, upload-time = "2026-03-31T22:39:53.105Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/f8/7aacb8e5f4a7899d39c787b5984e912e6c18b11be136ef13947d7a66d265/hf_xet-1.4.3-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:e23717ce4186b265f69afa66e6f0069fe7efbf331546f5c313d00e123dc84583", size = 3562178, upload-time = "2026-03-31T22:39:51.295Z" },
+    { url = "https://files.pythonhosted.org/packages/df/9a/a24b26dc8a65f0ecc0fe5be981a19e61e7ca963b85e062c083f3a9100529/hf_xet-1.4.3-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc360b70c815bf340ed56c7b8c63aacf11762a4b099b2fe2c9bd6d6068668c08", size = 4212320, upload-time = "2026-03-31T22:39:42.922Z" },
+    { url = "https://files.pythonhosted.org/packages/53/60/46d493db155d2ee2801b71fb1b0fd67696359047fdd8caee2c914cc50c79/hf_xet-1.4.3-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:39f2d2e9654cd9b4319885733993807aab6de9dfbd34c42f0b78338d6617421f", size = 3991546, upload-time = "2026-03-31T22:39:41.335Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/f5/067363e1c96c6b17256910830d1b54099d06287e10f4ec6ec4e7e08371fc/hf_xet-1.4.3-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:49ad8a8cead2b56051aa84d7fce3e1335efe68df3cf6c058f22a65513885baac", size = 4193200, upload-time = "2026-03-31T22:40:01.936Z" },
+    { url = "https://files.pythonhosted.org/packages/42/4b/53951592882d9c23080c7644542fda34a3813104e9e11fa1a7d82d419cb8/hf_xet-1.4.3-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7716d62015477a70ea272d2d68cd7cad140f61c52ee452e133e139abfe2c17ba", size = 4429392, upload-time = "2026-03-31T22:40:03.492Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/21/75a6c175b4e79662ad8e62f46a40ce341d8d6b206b06b4320d07d55b188c/hf_xet-1.4.3-cp37-abi3-win_amd64.whl", hash = "sha256:6b591fcad34e272a5b02607485e4f2a1334aebf1bc6d16ce8eb1eb8978ac2021", size = 3677359, upload-time = "2026-03-31T22:40:13.619Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/7c/44314ecd0e89f8b2b51c9d9e5e7a60a9c1c82024ac471d415860557d3cd8/hf_xet-1.4.3-cp37-abi3-win_arm64.whl", hash = "sha256:7c2c7e20bcfcc946dc67187c203463f5e932e395845d098cc2a93f5b67ca0b47", size = 3533664, upload-time = "2026-03-31T22:40:12.152Z" },
 ]
 
 [[package]]
@@ -1252,21 +1176,22 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "0.36.2"
+version = "1.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
     { name = "packaging" },
     { name = "pyyaml" },
-    { name = "requests" },
     { name = "tqdm" },
+    { name = "typer" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7c/b7/8cb61d2eece5fb05a83271da168186721c450eb74e3c31f7ef3169fa475b/huggingface_hub-0.36.2.tar.gz", hash = "sha256:1934304d2fb224f8afa3b87007d58501acfda9215b334eed53072dd5e815ff7a", size = 649782, upload-time = "2026-02-06T09:24:13.098Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/89/e7aa12d8a6b9259bed10671abb25ae6fa437c0f88a86ecbf59617bae7759/huggingface_hub-1.11.0.tar.gz", hash = "sha256:15fb3713c7f9cdff7b808a94fd91664f661ab142796bb48c9cd9493e8d166278", size = 761749, upload-time = "2026-04-16T13:07:39.73Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/af/48ac8483240de756d2438c380746e7130d1c6f75802ef22f3c6d49982787/huggingface_hub-0.36.2-py3-none-any.whl", hash = "sha256:48f0c8eac16145dfce371e9d2d7772854a4f591bcb56c9cf548accf531d54270", size = 566395, upload-time = "2026-02-06T09:24:11.133Z" },
+    { url = "https://files.pythonhosted.org/packages/37/02/4f3f8997d1ea7fe0146b343e5e14bd065fa87af790d07e5576d31b31cc18/huggingface_hub-1.11.0-py3-none-any.whl", hash = "sha256:42a6de0afbfeb5e022222d36398f029679db4eb4778801aafda32257ae9131ab", size = 645499, upload-time = "2026-04-16T13:07:37.716Z" },
 ]
 
 [[package]]
@@ -2166,7 +2091,6 @@ all-providers = [
 ]
 dev = [
     { name = "pytest" },
-    { name = "pytest-cov" },
 ]
 google = [
     { name = "google-genai" },
@@ -2175,9 +2099,9 @@ huggingface = [
     { name = "huggingface-hub" },
 ]
 local = [
-    { name = "flashinfer-cubin", marker = "sys_platform == 'linux'" },
-    { name = "flashinfer-python", marker = "sys_platform == 'linux'" },
+    { name = "deep-gemm", marker = "sys_platform == 'linux'" },
     { name = "hf-transfer", marker = "sys_platform == 'linux'" },
+    { name = "transformers", marker = "sys_platform == 'linux'" },
     { name = "vllm", marker = "sys_platform == 'linux'" },
 ]
 openai = [
@@ -2187,8 +2111,7 @@ openai = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.42.0" },
-    { name = "flashinfer-cubin", marker = "sys_platform == 'linux' and extra == 'local'", specifier = "==0.6.6" },
-    { name = "flashinfer-python", marker = "sys_platform == 'linux' and extra == 'local'", specifier = "==0.6.6" },
+    { name = "deep-gemm", marker = "sys_platform == 'linux' and extra == 'local'", path = "deep_gemm-2.3.0+477618c-cp313-cp313-linux_x86_64.whl" },
     { name = "google-genai", marker = "extra == 'all-providers'", specifier = ">=1.0" },
     { name = "google-genai", marker = "extra == 'google'", specifier = ">=1.0" },
     { name = "hf-transfer", marker = "sys_platform == 'linux' and extra == 'local'" },
@@ -2199,13 +2122,13 @@ requires-dist = [
     { name = "openai", marker = "extra == 'all-providers'", specifier = ">=1.0" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'" },
     { name = "python-dotenv", specifier = ">=1.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.0" },
     { name = "scipy", specifier = ">=1.14" },
     { name = "sympy", specifier = ">=1.13" },
-    { name = "vllm", marker = "sys_platform == 'linux' and extra == 'local'", specifier = "==0.19.0" },
+    { name = "transformers", marker = "sys_platform == 'linux' and extra == 'local'", specifier = ">=5.5.4" },
+    { name = "vllm", marker = "sys_platform == 'linux' and extra == 'local'", specifier = ">=0.19.1" },
 ]
 provides-extras = ["dev", "openai", "google", "huggingface", "all-providers", "local"]
 
@@ -2905,20 +2828,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
-]
-
-[[package]]
-name = "pytest-cov"
-version = "7.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "coverage" },
-    { name = "pluggy" },
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
 ]
 
 [[package]]
@@ -3706,23 +3615,22 @@ wheels = [
 
 [[package]]
 name = "transformers"
-version = "4.57.6"
+version = "5.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "filelock" },
     { name = "huggingface-hub" },
     { name = "numpy" },
     { name = "packaging" },
     { name = "pyyaml" },
     { name = "regex" },
-    { name = "requests" },
     { name = "safetensors" },
     { name = "tokenizers" },
     { name = "tqdm" },
+    { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/35/67252acc1b929dc88b6602e8c4a982e64f31e733b804c14bc24b47da35e6/transformers-4.57.6.tar.gz", hash = "sha256:55e44126ece9dc0a291521b7e5492b572e6ef2766338a610b9ab5afbb70689d3", size = 10134912, upload-time = "2026-01-16T10:38:39.284Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/e9/c6c80a07690142a7d05444271f47b9f3c8aac7dea01d52e1137ee480ad78/transformers-5.6.2.tar.gz", hash = "sha256:e657134c3e5a6bc00a3c35f4e2674bb51adfcd89898495b788a18552bac2b91a", size = 8311867, upload-time = "2026-04-23T18:33:29.332Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/b8/e484ef633af3887baeeb4b6ad12743363af7cce68ae51e938e00aaa0529d/transformers-4.57.6-py3-none-any.whl", hash = "sha256:4c9e9de11333ddfe5114bc872c9f370509198acf0b87a832a0ab9458e2bd0550", size = 11993498, upload-time = "2026-01-16T10:38:31.289Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/95/0b0218149b0d6f14df35f5b8f676fa83df4f19ed253c3cc447107ef86eca/transformers-5.6.2-py3-none-any.whl", hash = "sha256:f8d3a1bb96778fed9b8aabfd0dd6e19843e4b0f2bb6b59f32b8a92051b0f348f", size = 10364898, upload-time = "2026-04-23T18:33:26.081Z" },
 ]
 
 [[package]]
@@ -3832,7 +3740,7 @@ wheels = [
 
 [[package]]
 name = "vllm"
-version = "0.19.0"
+version = "0.19.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -3901,10 +3809,10 @@ dependencies = [
     { name = "watchfiles" },
     { name = "xgrammar", marker = "platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'ppc64le' or platform_machine == 's390x' or platform_machine == 'x86_64'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/03/14/c330a72309051f762b357a2e41d5015bedbb106ad1e16a231bdfda2e2163/vllm-0.19.0.tar.gz", hash = "sha256:81e59cf87175e7a62eb8d9acf5989484bbd17089d5eface353f89067bda282d9", size = 31071745, upload-time = "2026-04-03T04:04:52.833Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/49/60a2a962ecbf780c8fbfd0d5548b208d654d5c4267df94d8d93883641431/vllm-0.19.1.tar.gz", hash = "sha256:9fb88ce6b50991eba41d183584f65f51d7f6015d86a42cdabf79c1c8bd5d66fa", size = 31105401, upload-time = "2026-04-18T05:50:15.143Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/51/467e7a8cb4838022daa731b7f8b34c228691e36f938e1803c3a702c7bd69/vllm-0.19.0-cp38-abi3-manylinux_2_31_aarch64.whl", hash = "sha256:6ab90ccca5d7ca3bd2c8f90133f0fac85e8f4af582a1c67c6cc3f63c615521e3", size = 384650557, upload-time = "2026-04-03T04:05:52.513Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/08/6a431731e4c163bc1fab85b63e269d84104aad0fba98dac1af34fdc5077f/vllm-0.19.0-cp38-abi3-manylinux_2_31_x86_64.whl", hash = "sha256:2d0e5fae45367bdbf111fcad68f4c0f8fdddd2f2fb643e52f0f2daebef7b41cf", size = 432281473, upload-time = "2026-04-03T04:05:22.07Z" },
+    { url = "https://files.pythonhosted.org/packages/28/4c/26c426103c58ac8d98435fe63c7758a2f289b5481a08be19e9c9fe29a4c2/vllm-0.19.1-cp38-abi3-manylinux_2_31_aarch64.whl", hash = "sha256:c8dde3c9af20f00a644e64a50ebe43948f2921bab3ffd5407d634c15836cb181", size = 385252556, upload-time = "2026-04-18T05:49:16.101Z" },
+    { url = "https://files.pythonhosted.org/packages/78/20/f41216b79c87372a9d03175f36fa1411ee61059ce8c557d2691722ea4aae/vllm-0.19.1-cp38-abi3-manylinux_2_31_x86_64.whl", hash = "sha256:71a87f46cafab4489c69a5c5c83b870d0235e5694d8222303d460576293dc719", size = 433132101, upload-time = "2026-04-18T05:49:54.202Z" },
 ]
 
 [[package]]


### PR DESCRIPTION

## Summary

Adds end-to-end support for two huge open-weight reasoning models on our Slurm/H100 cluster, plus a `serve/full_eval.slurm` wrapper for sweeping the entire 70-problem CritPt set against a single serve job.

For Kimi-K2.6 we tuned the vLLM args from a ~22 tok/s eager baseline up to **~90 tok/s single-request / ~335 tok/s aggregate at 8-way concurrency** — a roughly 4× throughput improvement. Single-problem CritPt vibe-check passed; the full 70-problem sweep is in flight.

For GLM-5.1 we landed on a ~7.5 tok/s configuration that loads in ~2 min on a warm page cache (down from ~37 min without prefetch, or a projected ~2.5 h on a cold cache). **Note: GLM-5.1 is roughly 10× slower per-token than Kimi-K2.6 on the same hardware, and we currently do not recommend running it for evals — see the README callout for details.**

## Headline results

Load times are vLLM's "Loading weights took N seconds" reported by the slowest worker. They depend heavily on OS page-cache state, so two columns:

| Model | Nodes | Tput (1 req) | Tput (8-way batch) | Load (cold cache) | Load (warm cache, chosen) | Quality |
|-------|-------|--------------|--------------------|-------------------|----------------------------|---------|
| `zai-org/GLM-5.1`      | 3 | ~7.5 tok/s | ~50 tok/s  | ~2.5 h projected (no prefetch); ~2 min projected (prefetch) | **~2 min** (prefetch) vs ~37 min (no prefetch) | passes single-problem CritPt vibe check |
| `moonshotai/Kimi-K2.6` | 4 | ~90 tok/s  | ~335 tok/s | ~78 min (no prefetch); cold + prefetch untested | **~6-9 min** (prefetch ≈ no-prefetch when warm) | passes single-problem CritPt vibe check; 70-problem sweep resumed in job 22091289 from a partial run (7/70 already scored) |

The single-problem CritPt run is just a vibe check (`problems/critpt/quantum_error_correction_main.yaml`) to confirm the serve pipeline emits a parseable answer. Real quality numbers will come from the 70-problem sweep in `serve/full_eval.slurm`.

## What this PR changes

### `pyproject.toml`

- `vllm` floor bumped from `==0.19.0` to `>=0.19.1` (latest on PyPI). vLLM 0.20.0 is tagged on GitHub (2026-04-23) but not yet on PyPI; bump to `>=0.20` once it ships.
- `transformers>=5.5.4` pinned in the `local` extra so `uv sync` cannot downgrade it. GLM-5.1's `glm_moe_dsa` architecture requires it; vLLM only requires `>=4.56.0`.
- Removed `flashinfer-python` and `flashinfer-cubin` from our optional-deps — vLLM 0.19.1 already pins both to `==0.6.6` transitively, so listing them here was redundant.
- Removed `pytest-cov` from `dev` (never invoked anywhere — no `--cov` in any config).
- We tried `runai-model-streamer` as a loader; it was slower than `prefetch` on Weka, so it has been dropped from deps and from `models.yaml`.

### `src/open_dirac/models.yaml`

- New entry `zai-org/GLM-5.1`:
  - `nodes: 3`, `gpus_per_node: 8`
  - `--max-model-len 163840`, `--trust-remote-code`
  - `--safetensors-load-strategy prefetch` (mandatory on Weka — 17× faster shard reads even with a warm cache)
  - `--enforce-eager` (mandatory: DeepGEMM JIT crashes during torch.compile graph capture for the sparse-attention indexer)
- New entry `moonshotai/Kimi-K2.6`:
  - `nodes: 4`, `gpus_per_node: 8`
  - `--max-model-len 262144`, `--trust-remote-code`
  - `--safetensors-load-strategy prefetch` — defensive (helps on cold cache; a no-op once weights are in the OS page cache)
  - `--enable-expert-parallel` (free 3-4% throughput on this MoE)
  - **No** `--enforce-eager` — CUDA graphs give the dominant ~4× speedup
- `max_output_tokens: 131072` on both new entries, plus `reasoning_format: separate_field` and `tool_mode: api`. **No existing model entries' `max_output_tokens` were touched** — only the two new ones above.
- A multi-paragraph comment block above each entry catalogs every flag combination tried, with results and load timings, so future tuning attempts have an audit trail and don't repeat failed experiments.

### `serve/serve.slurm` + `serve/resolve_serve_config.py`

- `resolve_serve_config.py` now extracts and exports `DEFAULT_MODEL_ID` from `models.yaml` (the underlying HF repo ID, distinct from the friendly alias users pass to `--model`).
- `serve.slurm` now uses `$DEFAULT_MODEL_ID` (not the alias) in the `vllm serve` command, so vLLM downloads from / serves the correct HF repo even when launched via an alias key.
- Unblocks running multiple alias variants of the same underlying model in parallel without each one trying to fetch the alias from HuggingFace.

### `serve/eval.slurm`

- Default time limit bumped from 02:00:00 to 08:00:00 (huge models can spend an hour just on a single hard CritPt problem).
- Health-check max wait bumped from 30 min to 4 h to cover a cold-cache Kimi load.
- Usage block updated with GLM-5.1 and Kimi-K2.6 examples.

### `serve/full_eval.slurm` (new)

- Submits a single `hopper-prod` job that runs `scripts/run_critpt_oneshot.py` with `--concurrency N` parallel in-flight requests against a vLLM serve endpoint.
- Reads `endpoint.env` from the serve job, exports `VLLM_BASE_URL` so the OpenAI-compatible client connects to the head node, and waits up to 4 hours for `/health` before starting.
- Writes submissions to `results/critpt_oneshot/<model_slug>/<timestamp>/`, fully compatible with the existing resume logic.

### `scripts/run_critpt_common.py` + the three orchestrators

- New `write_initial_batch_metadata(...)` helper writes a `batch_metadata.json` stub with the run's configs and an empty `problems` list immediately after `start_time` is captured, *before* any workers spawn.
- Wired into `run_critpt_oneshot.py`, `run_critpt_rsa.py`, and `run_critpt_open_dirac.py`.
- Why: the old `write_batch_metadata(...)` only fired at the end of a run, so any killed run left an unresumable directory (the `--resume` path hard-requires `batch_metadata.json`). With this fix, killing a run at any point — even before the first problem completes — leaves a directory that `--resume DIR` can pick up cleanly. We hit this exact failure in this PR's Kimi production eval and had to hand-write a stub mid-stream; this prevents the next person from doing the same.

### `tests/test_config.py` + `tests/test_run_critpt_common.py`

`tests/test_config.py`:
- `TestModelRegistryResolution` — end-to-end `Config(model=...)` for both new model keys (provider, model_id, max_tokens, reasoning fields).
- `TestServeConfig` — pins the `serve` block (nodes, gpus_per_node, key vllm_args presence) for GLM-5.1 and Kimi-K2.6 directly against `models.yaml`, so a drive-by yaml edit cannot silently break the launcher (e.g. dropping `--enforce-eager` from GLM, or accidentally adding it to Kimi).
- `TestResolveServeConfig` — runs `serve/resolve_serve_config.py` as a subprocess and asserts `DEFAULT_MODEL_ID` (new in this PR), `DEFAULT_NODES`, `DEFAULT_GPUS_PER_NODE`, and key `DEFAULT_VLLM_ARGS` tokens are emitted for both models, plus a graceful-fallback case for unknown model keys.

`tests/test_run_critpt_common.py`:
- `test_initial_metadata_makes_killed_run_resumable` — the stub is a valid `--resume` target with zero completed problems, and the end-of-run write merges results into it without losing configs.
- `test_find_completed_submissions_*` — covers the resume-skip contract: only files with both `problem_id` and `generated_code` count; corrupt JSON, partial submissions, subdirs, and the metadata file itself are correctly ignored.
- `test_load_resume_config_missing_metadata_exits_cleanly` — verifies the resume path exits with code 1 (not a stack trace) when `batch_metadata.json` is absent. The new `write_initial_batch_metadata` makes this case unreachable on freshly-killed runs, but the error path still matters for users pointing `--resume` at the wrong directory.

### `README.md`

- New "Performance tuning notes for huge models" section under serving, with a tput/load-time table that distinguishes cold-cache from warm-cache and a list of flags that did and did not help on H100/Weka.
- New "Step 3 (optional): Full benchmark sweep" section documenting `serve/full_eval.slurm`.
- Local model list now includes `moonshotai/Kimi-K2.6` and `zai-org/GLM-5.1` with node counts.
- Added an explicit "**Not recommended**" callout above the GLM-5.1 example explaining that GLM is ~10× slower than Kimi because `--enforce-eager` (required for stability) disables the CUDA-graph win.

## Experiments performed (kept for context)

The full audit trail lives in `models.yaml` comments. Summary of what we tried and discarded:

### GLM-5.1
- `runai_streamer` loader → ~6 min vs ~2 min prefetch on a warm cache (slower).
- `--enable-expert-parallel` → 7.5 tok/s, identical to baseline (32 experts already distributed well across PP=3/TP=8).
- Removing `--enforce-eager` → DeepGEMM `CUDA_ERROR_FILE_NOT_FOUND` JIT crash during graph capture. Required.
- ngram speculative decoding → blocked: vLLM 0.19.1 disallows spec decoding with PP > 1.

### Kimi-K2.6
- **MTP**: blocked. K2.6 dropped K2's `num_nextn_predict_layers` to 0 → no MTP weights.
- **EAGLE/Medusa**: blocked. No draft weights ship with K2.6.
- **Suffix decoding**: blocked. Requires `arctic-inference`, whose CMake build needs C++20 `<span>`; system GCC 9.4 lacks it.
- **ngram (PP=4)**: crashed twice — vLLM bug #30436 (worked around with a one-line `hasattr(self, "drafter")` guard) plus a `total_num_scheduled_tokens > 0` scheduler assert with no good workaround. Confirms spec decoding is genuinely unsupported with PP > 1.
- **ngram (PP=2/TP=8)**: same PP+spec crash.
- **ngram (single-node TP=8/PP=1/EP)**: torch._inductor JIT crash analogous to GLM's; would need eager mode which kills throughput.
- **ngram (multi-node TP=16/PP=1/EP)**: ran! But only 40-45 tok/s — half the champion. Inter-node TP all-reduce on IB dominates, and 12-16% ngram acceptance doesn't compensate. Needed `max-model-len 131k` and `gpu-mem 0.85` to avoid OOM during generation.
- **EP without dropping `--enforce-eager`**: ~21 tok/s, no win. EP only matters once CUDA graphs are on.
- **`--kv-cache-dtype fp8`** (champion + fp8 KV): warm single-req ~74 tok/s vs ~90 bf16 (~18% slower from per-step dequant). Its only benefit is ~50% KV-cache memory, which we don't need — the champion already runs at ~12-15% KV utilization at 8-way concurrency. Rejected.
- **PP=2/TP=8 (2 nodes)**: ~43 tok/s single-req on 16 GPUs vs ~90 tok/s on 32 GPUs (champion). Linear per-GPU scaling, no per-request win from fewer pipeline stages. Confirms further PP reduction does not unlock single-request latency on Kimi.

### DeepSeek-V4-Pro (1.6T MoE, released 2026-04-24)
- Dead-on-arrival on vLLM 0.19.1: no `DeepseekV4ForCausalLM` in the model registry, transformers doesn't recognise `model_type=deepseek_v4`, and the novel CSA+HCA attention has no kernel here. Documented as a non-runnable comment in `models.yaml`; revisit when vLLM 0.20+ ships DSV4 support.

### FlashAttention 4
- Confirmed not usable on Hopper: vLLM's `fa_utils.py` only enables FA4 on SM100+ (Blackwell). FA4 also doesn't support MLA's non-standard head dims, so it would skip Kimi/GLM regardless. We already use FA3, which IS the latest supported FA on H100.

## Test plan

- [x] GLM-5.1 serve job loads in ~2 min on warm cache, single-request CritPt vibe check emits a correct answer at ~7.5 tok/s.
- [x] Kimi-K2.6 serve job loads in ~6-9 min on warm cache, single-request CritPt vibe check emits a correct answer at ~90 tok/s.
- [x] Kimi-K2.6 8-way concurrent run sustains ~335 tok/s aggregate (steady-state).
- [ ] Full 70-problem CritPt sweep on Kimi-K2.6 completes (resumed in job 22091289 from 7/70; ETA ~2 h on the remaining 63).
- [x] Resubmitting either serve job picks up the cached weights from `~/.cache/huggingface/`.
- [x] `serve/eval.slurm --serve-job <ID>` works end-to-end against both models.
- [x] `serve/full_eval.slurm --serve-job <ID>` writes submissions to `results/critpt_oneshot/<model>/<timestamp>/` and supports resume.
- [x] `pytest tests/test_config.py::TestModelRegistryResolution` passes.

## Future work (intentionally out of scope)

- **Data-parallel scaling for the eval pipeline.** Per-replica vertical scaling on Kimi has hit its ceiling on H100/Weka — extra TP across nodes is bandwidth-bound, extra PP doesn't speed up single requests, and EP has marginal returns. The right next axis is data parallelism: replicate the 4-node serve N times and place a tiny OpenAI-compatible router in front so the eval client still sees a single endpoint and can scale its concurrency to `N × 8`. This is a self-contained follow-up PR (router + small `eval.slurm` change). Punted from this PR to keep it focused.
- **Concurrency tuning beyond 8.** The champion serve runs at ~12-15% KV-cache utilization at 8-way concurrency, so there is meaningful headroom — the limiting factor is per-request latency, not memory. Worth a sweep (16 / 24 / 32) once we adopt the DP router so we're tuning aggregate throughput, not single-replica saturation.
- **DeepSeek-V4-Pro** once vLLM 0.20+ ships CSA+HCA support (see `models.yaml` comment).

## Reproducing the env

One command:

```bash
uv sync --extra local
```

`deep_gemm` is installed automatically via `[tool.uv.sources]` in `pyproject.toml` (the wheel is checked into the repo root because it's not on PyPI; GLM-5.1's sparse-attention indexer needs it). No other manual steps.

## Notes

- The DSV4-Pro entry intentionally lives only as a comment block in `models.yaml`, not a YAML entry, to avoid users tripping over a config that fails immediately on vLLM 0.19.1. Promote to an entry once vLLM 0.20+ ships CSA+HCA support.
- The `arctic-inference` build failure (suffix speculative decoding) is documented in `models.yaml`; revisit only if we get GCC 10+ in the venv and want to chase spec-decoding wins beyond what we already explored.
- During exploration we vendored a one-line patch in `.venv/.../gpu_model_runner.py` to work around vLLM bug #30436 (drafter attr accessed on non-last PP ranks). That patch is now reverted: the chosen Kimi and GLM configs don't use speculative decoding, so the buggy code path is unreachable in production. The bug + workaround stays documented in the Kimi `models.yaml` comment block for future spec-decoding experiments.

Made with [Cursor](https://cursor.com)