### PR TITLE
Tune GLM-5.1 serving after DeepGEMM investigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Running a local model is a two-step process: first **serve** the model with vLLM
 # as soon as the job starts (before the model finishes loading).
 
 # Step 2 — Run a problem against the served model
-# eval.slurm reads endpoint.env, waits for vLLM to be healthy (up to 30 min),
+# eval.slurm reads endpoint.env, waits for vLLM to be healthy (up to 4 h),
 # then launches the evaluation.
 ./serve/eval.slurm \
   --model nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16 \
@@ -220,13 +220,9 @@ Running a local model is a two-step process: first **serve** the model with vLLM
 
 #### Huge-model example (GLM-5.1)
 
-> **Not recommended.** `zai-org/GLM-5.1` is roughly **10× slower** than
-> `moonshotai/Kimi-K2.6` on the same hardware (~7.5 vs ~86 tok/s single-request).
-> The bottleneck is `--enforce-eager`, which is required to avoid a DeepGEMM JIT
-> crash in GLM's `glm_moe_dsa` sparse-attention path during CUDA graph capture.
-> Eager mode disables CUDA graphs and `torch.compile`, which is the dominant
-> speedup we get on Kimi. Until that DeepGEMM/`torch.compile` interaction is
-> fixed upstream, prefer Kimi-K2.6 for evals on this stack.
+`zai-org/GLM-5.1` runs on 3 H100 nodes with the default `models.yaml` serve
+config. The script pins DeepGEMM's JIT cache to `/fsx` and uses the loaded
+CUDA 12.9 toolkit so GLM can run without `--enforce-eager`.
 
 ```bash
 ./serve/serve.slurm \
@@ -246,6 +242,9 @@ Running a local model is a two-step process: first **serve** the model with vLLM
 
 - `uv sync --extra local`
 - `uv run hf auth whoami`
+- The `local` extra installs `vllm`, the required `transformers` floor, and the
+  vendored `deep-gemm` wheel from `[tool.uv.sources]`; no manual DeepGEMM install
+  is needed for `zai-org/GLM-5.1`.
 - vendored Nemotron parser plugins live in `serve/reasoning_parsers/`
 
 #### Step 1: Serve the model
@@ -297,18 +296,36 @@ The `--reasoning-parser` flag is exposed directly. Use it to enable built-in par
 
 #### Performance tuning notes for huge models
 
-Per-model `vllm_args` in `models.yaml` already encode the fastest configuration we found on our cluster (4×H100 80 GB nodes, WekaFS-backed weights). The full experiment log is in the comments above each entry; the headline results:
+Per-model `vllm_args` in `models.yaml` already encode the fastest configuration we found on our cluster (H100 80 GB nodes, WekaFS-backed weights). The full experiment log is in the comments above each entry; the headline results:
 
 Load times below are wall time of `default_loader.py` "Loading weights took N seconds" on the slowest worker. They depend heavily on whether the OS page cache is warm.
 
-| Model | Tput (single req) | Tput (8-way batch) | Load (cold cache) | Load (warm cache) | Notes |
-|-------|-------------------|--------------------|-------------------|-------------------|-------|
-| `zai-org/GLM-5.1`      | ~7.5 tok/s | ~50 tok/s  | ~2.5h (no prefetch) → ~2 min (with prefetch, projected) | ~37 min (no prefetch) → **~2 min (with prefetch, chosen)** | `--enforce-eager` is **required** (DeepGEMM JIT crash without it). EP gives 0% gain. |
-| `moonshotai/Kimi-K2.6` | ~90 tok/s  | ~335 tok/s | ~78 min (no prefetch); prefetch on cold cache untested | ~6-9 min (no prefetch ≈ prefetch) | CUDA graphs (no `--enforce-eager`) give the dominant 4× throughput win; `--enable-expert-parallel` adds ~3-4%. |
+| Model | Tput (single req) | Tput (8-way batch) | Tput (16-way batch) | Load (cold cache) | Load (warm cache) | Notes |
+|-------|-------------------|--------------------|---------------------|-------------------|-------------------|-------|
+| `zai-org/GLM-5.1`      | ~46 tok/s | ~202 tok/s | ~333 tok/s | ~2.5h projected without prefetch | ~18-22 min with prefetch in the final run; earlier warm run was ~2 min | DeepGEMM JIT cache/toolkit setup lets this run without `--enforce-eager`; BF16 beats FP8 on our stack. |
+| `moonshotai/Kimi-K2.6` | ~92 tok/s | ~558 tok/s | ~920 tok/s | ~78 min without prefetch; prefetch on cold cache untested | ~6-11 min with warm cache | CUDA graphs (no `--enforce-eager`) give the dominant 4× throughput win; `--enable-expert-parallel` remains the chosen default. |
+
+For an apples-to-apples 4-node comparison, GLM-5.1 with TP=8/PP=4 measured
+~46 tok/s single-request, ~257 tok/s at 8-way concurrency, and ~383 tok/s at
+16-way concurrency. That improves aggregate throughput over the 3-node default,
+but not single-request latency, and the gain is smaller than the extra 33% GPU
+cost, so the default stays at 3 nodes.
+
+Kimi-K2.6 also fits on fewer nodes. With the same canonical flags:
+
+| Kimi nodes | Tput (single req) | Tput (8-way batch) | Tput (16-way batch) | Full-context KV headroom | Notes |
+|------------|-------------------|--------------------|---------------------|--------------------------|-------|
+| 2 | ~94 tok/s | ~569 tok/s | ~938 tok/s | 3.83× at 262k context | Best short-prompt cost/perf, but risky for full 8-way long-context sweeps. |
+| 3 | ~92 tok/s | ~547 tok/s | ~920 tok/s | 7.48× at 262k context | Almost enough for 8-way full-context use, still less headroom than 4 nodes. |
+| 4 | ~92 tok/s | ~558 tok/s | ~920 tok/s | 11.12× at 262k context | Chosen default for robust 8-way CritPt runs. |
+
+Kimi's `max_output_tokens` is intentionally `200000`. The old 131k cap left
+five hard one-shot CritPt problems without parseable answer code; rerunning just
+those with the higher cap completed the full 70/70 submission set.
 
 Two flags worth knowing whenever you add a new huge model on a networked filesystem:
 
-- `--safetensors-load-strategy prefetch` — pulls all shards into the OS page cache via background threads. Mandatory on WekaFS / Lustre / NFS where vLLM's auto-detection often misses and falls back to slow random mmap reads. Confirmed 17× speedup on GLM-5.1 even on a warm cache (282 shards); on Kimi-K2.6 (64 shards) it's a no-op once the cache is warm but still recommended for the very first load.
+- `--safetensors-load-strategy prefetch` — pulls all shards into the OS page cache via background threads. Mandatory on WekaFS / Lustre / NFS where vLLM's auto-detection often misses and falls back to slow random mmap reads. It is still the best loader we found for GLM/Kimi; exact wall time depends heavily on cluster cache state.
 - `--enable-expert-parallel` — for MoE models with many experts (Kimi has 384), shard them across the TP group rather than replicate. Free win for Kimi-class models.
 
 What does **not** help on H100:
@@ -316,6 +333,8 @@ What does **not** help on H100:
 - `--load-format runai_streamer` — slower than `prefetch` on Weka (~6 min vs ~2 min for GLM on a warm cache).
 - FlashAttention 4 — only supported on Blackwell (SM100+); Hopper falls back to FA3 (which is already what we use).
 - ngram / EAGLE / Medusa / MTP / suffix speculative decoding for Kimi-K2.6 — all blocked: Kimi-K2.6 dropped MTP layers, no draft weights ship with it, suffix decoding's `arctic-inference` build needs C++20 `<span>` (GCC 9.4 lacks it), and ngram is incompatible with PP > 1 in vLLM 0.19.1. Pure-TP multi-node ngram works but is slower than the no-spec config because inter-node TP all-reduce dominates.
+- `--async-scheduling`, `--mm-encoder-tp-mode data`, and the Kimi-K2.5 Eagle3 draft for Kimi-K2.6 — no throughput win or not runnable. K2.5 Eagle3 cannot be used with PP > 1, and TP-only Kimi trips the multimodal vision-tower path in vLLM 0.19.1.
+- `zai-org/GLM-5.1-FP8` on this pip/wheel stack — no-eager repeatedly fails in DeepGEMM FP8 warmup with `CUDA_ERROR_FILE_NOT_FOUND`, even with isolated DeepGEMM and TorchInductor caches. Eager FP8 serves, but the best measured MTP=3 run was only ~11 tok/s single-request and ~157 tok/s at 16-way concurrency.
 - `--kv-cache-dtype fp8` for Kimi-K2.6 — ~18% slower single-request (per-step dequant) and the only benefit is ~50% KV-cache memory, which is unused: the champion runs at ~12-15% KV utilization at 8-way concurrency.
 - Reducing pipeline parallelism (PP=2/TP=8 on 2 nodes vs PP=4/TP=8 on 4 nodes) — gives linear per-GPU scaling (~43 vs ~90 tok/s single-req), no per-request latency win from fewer stages.
 
@@ -328,7 +347,7 @@ Local model keys match Hub repo IDs:
 - `nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16`
 - `nvidia/Nemotron-Cascade-2-30B-A3B`
 - `moonshotai/Kimi-K2.6` (4 nodes; 1T-parameter MoE, native int4 quantization)
-- `zai-org/GLM-5.1` (3 nodes; sparse-attention MoE — see "Not recommended" note above)
+- `zai-org/GLM-5.1` (3 nodes; sparse-attention MoE)
 
 #### Step 2: Run the problem
 

--- a/serve/serve.slurm
+++ b/serve/serve.slurm
@@ -323,6 +323,17 @@ fi
 
 export TORCH_COMPILE_DISABLE=1
 
+# DeepGEMM JIT compiles sparse-attention kernels (used by GLM-5.1 and DSv3-class
+# MoE models) at first call. Put cubins in the shared HF cache when available so
+# all Slurm ranks see the same writable path and kernels survive across jobs.
+# Also point JIT at the CUDA toolkit just loaded above.
+SHARED_CACHE_ROOT="${HUGGINGFACE_HUB_CACHE:-${REPO_ROOT}/.cache}"
+export DG_JIT_CACHE_DIR="${DG_JIT_CACHE_DIR:-${SHARED_CACHE_ROOT}/deep_gemm_jit}"
+mkdir -p "$DG_JIT_CACHE_DIR"
+if [[ -n "${CUDA_HOME:-}" && -x "${CUDA_HOME}/bin/nvcc" ]]; then
+  export DG_JIT_NVCC_COMPILER="${CUDA_HOME}/bin/nvcc"
+fi
+
 if ! uv run --no-sync hf auth whoami >/dev/null 2>&1; then
   echo "Hugging Face auth missing. Run 'uv run hf auth login' first." >&2
   exit 1

--- a/src/open_dirac/models.yaml
+++ b/src/open_dirac/models.yaml
@@ -280,26 +280,41 @@ nvidia/Nemotron-Cascade-2-30B-A3B:
       - --enable-auto-tool-choice
       - --tool-call-parser qwen3_coder
 
-# GLM-5.1: 3 nodes (24 H100), prefetch loader + eager. ~7.5 tok/s single-req.
+# GLM-5.1: 3 nodes (24 H100), prefetch loader + CUDA graphs. ~46 tok/s
+# single-request, ~202 tok/s aggregate at 8-way concurrency, ~333 tok/s at
+# 16-way concurrency.
 #
-# Experiments tried (all kept here as a record - none beat this config):
+# Experiments tried (all kept here as a record):
+# - WINNERS:
 # - --safetensors-load-strategy prefetch  → CHOSEN. Worker weight load went
 #   from 2214s (~37 min, warm page cache, no prefetch) to 128s (~2 min, warm
-#   page cache, prefetch) — a ~17x speedup just from running the shard reads
-#   in background threads. Cold-cache, no-prefetch was even worse: a first
-#   load only reached 29% of 282 shards in 44 min before we cancelled it,
-#   projecting to ~2.5h total.
-# - --load-format runai_streamer  → REJECTED. ~6 min load vs ~2 min prefetch
-#   on a warm cache. Multi-threaded direct CPU→GPU streaming is slower than
-#   letting the OS page cache stay warm.
-# - --enforce-eager  → REQUIRED. Without it, GLM's `glm_moe_dsa` sparse-
-#   attention indexer hits CUDA_ERROR_FILE_NOT_FOUND in DeepGEMM's JIT during
-#   torch.compile graph capture. Eager skips the capture path.
-# - --enable-expert-parallel  → REJECTED. Measured 7.5 tok/s, identical to
-#   baseline. GLM has fewer experts than Kimi (32 vs 384), so PP=3/TP=8
-#   already distributes them well; explicit EP adds nothing.
-# - ngram speculative decoding → BLOCKED. vLLM 0.19.1 explicitly disallows
-#   spec decoding with PP > 1 (see vLLM bugs #30436, #35521).
+#   page cache, prefetch) in the earlier run. Warm-cache reloads during the
+#   final sweep were still slower (~18-22 min on BF16), but prefetch remains
+#   the least bad loader for WekaFS.
+# - no --enforce-eager  → CHOSEN. The previous eager requirement was an
+#   environment issue: DeepGEMM JIT tried to use an unwritable/ephemeral cache
+#   and the old CUDA toolkit. serve.slurm now pins DG_JIT_CACHE_DIR to /fsx
+#   and DG_JIT_NVCC_COMPILER to the loaded cuda/12.9 toolkit, so GLM BF16 can
+#   use torch.compile/CUDA graphs. Throughput improved from ~7.5 tok/s eager
+#   to ~46 tok/s single-request.
+# - DEAD ENDS:
+#   - --load-format runai_streamer  → REJECTED. ~6 min load vs ~2 min prefetch
+#     on a warm cache in the original loader experiment.
+#   - --enable-expert-parallel  → REJECTED. Measured 7.5 tok/s under eager,
+#     identical to baseline. GLM has fewer experts than Kimi (32 vs 384), so
+#     PP=3/TP=8 already distributes them well; explicit EP adds nothing.
+#   - ngram speculative decoding → BLOCKED. vLLM 0.19.1 explicitly disallows
+#     spec decoding with PP > 1 (see vLLM bugs #30436, #35521).
+#   - 4-node BF16 (TP=8/PP=4) → REJECTED as default. This is the apples-to-
+#     apples comparison with Kimi's 4-node shape: ~46 tok/s single-request,
+#     ~257 tok/s aggregate at 8-way concurrency, and ~383 tok/s at 16-way.
+#     It improves aggregate throughput over 3 nodes but not single-request
+#     latency, and the gain is smaller than the extra 33% GPU cost.
+#   - zai-org/GLM-5.1-FP8 → REJECTED on this pip/wheel stack. FP8 no-eager
+#     repeatedly fails in DeepGEMM FP8 warmup with CUDA_ERROR_FILE_NOT_FOUND,
+#     even with isolated DeepGEMM and TorchInductor caches. Eager FP8 serves
+#     but is slow: official MTP=3 measured ~11 tok/s single-request, ~77 tok/s
+#     at 8-way concurrency, and ~157 tok/s at 16-way concurrency.
 zai-org/GLM-5.1:
   provider: vllm
   model_id: zai-org/GLM-5.1
@@ -316,10 +331,10 @@ zai-org/GLM-5.1:
       - --max-model-len 163840
       - --trust-remote-code
       - --safetensors-load-strategy prefetch
-      - --enforce-eager
 
-# Kimi-K2.6: 4 nodes (32 H100). ~90 tok/s single-request, ~335 tok/s aggregate
-# at 8-way concurrency. ~4x faster than the original eager-mode baseline.
+# Kimi-K2.6: 4 nodes (32 H100). ~92 tok/s single-request, ~558 tok/s aggregate
+# at 8-way concurrency and ~920 tok/s at 16-way concurrency. ~4x faster than
+# the original eager-mode baseline.
 #
 # Experiments tried (all kept here as a record):
 # - WINNERS:
@@ -372,6 +387,23 @@ zai-org/GLM-5.1:
 #     single-req vs 90 tok/s on 32 GPUs. Linear per-GPU scaling, no
 #     per-request win from fewer pipeline stages. Confirms that further PP
 #     reduction does not unlock single-request latency on Kimi.
+#   - Final reduced-node comparison with the canonical config:
+#     - 2 nodes (TP=8/PP=2) fits: ~94 tok/s single, ~569 tok/s at 8-way,
+#       ~938 tok/s at 16-way on short synthetic prompts, but KV capacity at
+#       full 262k context is only 3.83x. Good cost/perf for short prompts,
+#       risky as the default for full 8-way CritPt sweeps with long outputs.
+#     - 3 nodes (TP=8/PP=3) fits: ~92 tok/s single, ~547 tok/s at 8-way,
+#       ~920 tok/s at 16-way, with 7.48x full-context concurrency. Nearly
+#       enough for 8-way full-context use, but still less headroom than the
+#       4-node default's 11.12x.
+#   - Kimi-K2.5 recipe-inspired flags on K2.6 → NO WIN. Fresh canonical Kimi
+#     benchmarked ~92 tok/s single, ~558 tok/s aggregate at 8-way, and ~920
+#     tok/s at 16-way. --async-scheduling and --mm-encoder-tp-mode data tied
+#     that within noise. K2.5 Eagle3 draft is blocked: spec decoding cannot
+#     use PP>1, while TP=32/PP=1 fails during Kimi vision-tower init.
+#   - 131k max output tokens → TOO LOW for the full one-shot CritPt sweep.
+#     Five hard problems reached max_tokens before emitting answer code. Raising
+#     max_output_tokens to 200k let the final retry finish all 70 submissions.
 #   - Data-parallel scaling across replicas was not exercised here — needs
 #     a tiny OpenAI-compatible router in front to keep the eval client
 #     unchanged. Punted to a follow-up PR. This is the right next axis when
@@ -386,9 +418,10 @@ moonshotai/Kimi-K2.6:
   env_key: VLLM_API_KEY
   input_cost: 0.0
   output_cost: 0.0
-  # Half of --max-model-len so prompts (a few thousand tokens) fit alongside
-  # the generation budget without overflowing the model's context window.
-  max_output_tokens: 131072
+  # The hardest CritPt one-shot problems hit the old 131k cap before emitting
+  # parseable answer code. Keep a small buffer under the 262k context window for
+  # prompts while giving the model room to finish long reasoning traces.
+  max_output_tokens: 200000
   reasoning_format: separate_field
   tool_mode: api
   serve:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -178,7 +178,7 @@ class TestModelRegistryResolution:
         cfg = Config(model="moonshotai/Kimi-K2.6")
         assert cfg.provider == "vllm"
         assert cfg.model_id == "moonshotai/Kimi-K2.6"
-        assert cfg.max_tokens == 131072
+        assert cfg.max_tokens == 200000
         assert cfg.reasoning["reasoning_format"] == "separate_field"
         assert cfg.reasoning["tool_mode"] == "api"
 
@@ -189,7 +189,7 @@ class TestModelRegistryResolution:
 
 class TestServeConfig:
     """The serve.slurm script reads `serve.{nodes,gpus_per_node,vllm_args}` for
-    each model. These tests pin the contract for the two new huge models so a
+    each model. These tests pin the contract for the huge local models so a
     drive-by yaml edit cannot silently break the launcher."""
 
     @pytest.fixture(scope="class")
@@ -201,7 +201,8 @@ class TestServeConfig:
         assert serve["nodes"] == 3
         assert serve["gpus_per_node"] == 8
         args = " ".join(serve["vllm_args"])
-        assert "--enforce-eager" in args  # mandatory: DeepGEMM JIT crash without it
+        # DeepGEMM JIT cache/toolkit setup in serve.slurm makes CUDA graphs usable.
+        assert "--enforce-eager" not in args
         assert "--safetensors-load-strategy prefetch" in args  # 17x load speedup
         assert "--trust-remote-code" in args
 
@@ -256,7 +257,8 @@ class TestResolveServeConfig:
         assert out["DEFAULT_MODEL_ID"] == "zai-org/GLM-5.1"
         assert out["DEFAULT_NODES"] == "3"
         assert out["DEFAULT_GPUS_PER_NODE"] == "8"
-        assert "--enforce-eager" in out["DEFAULT_VLLM_ARGS"]
+        assert "--enforce-eager" not in out["DEFAULT_VLLM_ARGS"]
+        assert "--safetensors-load-strategy" in out["DEFAULT_VLLM_ARGS"]
 
     def test_unknown_model_falls_back_to_input_as_model_id(self):
         """No registry entry → DEFAULT_MODEL_ID == input model, no nodes/args."""


### PR DESCRIPTION
## Summary

This follow-up updates the huge-model serving defaults after the GLM/Kimi sweep:

- Fixes the GLM-5.1 DeepGEMM environment so BF16 GLM can run without `--enforce-eager`, enabling CUDA graphs and improving throughput from ~7.5 tok/s to ~46 tok/s single-request.
- Keeps the existing Kimi-K2.6 serving default unchanged after testing Kimi-K2.5 recipe-inspired variants; `--async-scheduling`, `--mm-encoder-tp-mode data`, and K2.5 Eagle3 did not improve K2.6 on this vLLM 0.19.1 stack.
- Raises Kimi's `max_output_tokens` to 200k after the old 131k cap caused five hard one-shot CritPt problems to stop before emitting parseable answer code.
- Documents why `zai-org/GLM-5.1-FP8` is not the chosen default here: no-eager FP8 repeatedly fails in DeepGEMM FP8 warmup, while eager FP8 serves but is slower than BF16 no-eager.

References used for the sweep:

- GLM vLLM recipe: https://github.com/vllm-project/recipes/blob/main/GLM/GLM5.md
- Kimi-K2.5 vLLM recipe: https://github.com/vllm-project/recipes/blob/main/moonshotai/Kimi-K2.5.md

## Headline Results

Throughput numbers are aggregate output token throughput from the synthetic OpenAI-compatible benchmark used during tuning. "8-way" and "16-way" mean 8 or 16 concurrent requests to the same vLLM endpoint.

| Model/config | Nodes | 1 req | 8-way | 16-way | Verdict |
|--------------|------:|------:|------:|-------:|---------|
| `zai-org/GLM-5.1` BF16, no eager | 3 | ~46 tok/s | ~202 tok/s | ~333 tok/s | New GLM default |
| `zai-org/GLM-5.1` BF16, no eager | 4 | ~46 tok/s | ~257 tok/s | ~383 tok/s | Comparable-to-Kimi run; not GPU-efficient enough for default |
| `zai-org/GLM-5.1-FP8`, eager, MTP=3 | 2 | ~11 tok/s | ~77 tok/s | ~157 tok/s | Too slow |
| `zai-org/GLM-5.1-FP8`, no eager | 2 | n/a | n/a | n/a | Fails DeepGEMM FP8 warmup |
| `moonshotai/Kimi-K2.6` canonical | 2 | ~94 tok/s | ~569 tok/s | ~938 tok/s | Fits; best short-prompt cost/perf, limited full-context KV headroom |
| `moonshotai/Kimi-K2.6` canonical | 3 | ~92 tok/s | ~547 tok/s | ~920 tok/s | Fits; nearly enough full-context headroom for 8-way |
| `moonshotai/Kimi-K2.6` canonical | 4 | ~92 tok/s | ~558 tok/s | ~920 tok/s | Existing default remains best |

The Kimi full CritPt result directory is now complete: `70/70` submission JSONs. It improved from 57/70 to 65/70 via normal retries, then the final five (`C21`, `C26`, `C27`, `C41`, `C52`) completed after increasing Kimi's max output cap to 200k.

## What Changed

- `serve/serve.slurm`
  - Loads `cuda/12.9` as before, then pins DeepGEMM JIT to a writable persistent cache under `HUGGINGFACE_HUB_CACHE` (or the repo-local `.cache` fallback).
  - Exports `DG_JIT_NVCC_COMPILER` from the loaded CUDA toolkit when available.
  - This is the key fix that lets BF16 GLM use the no-eager CUDA graph path.

- `pyproject.toml`
  - GLM installation stays reproducible through `uv sync --extra local`: the `local` extra includes `vllm`, the required `transformers` floor, and `deep-gemm`.
  - `deep-gemm` resolves from the vendored wheel via `[tool.uv.sources]`, so no manual DeepGEMM install is needed for the BF16 GLM default.

- `src/open_dirac/models.yaml`
  - Removes `--enforce-eager` from canonical `zai-org/GLM-5.1`.
  - Updates the GLM and Kimi experiment notes with the latest measurements and dead ends.
  - Raises `moonshotai/Kimi-K2.6` `max_output_tokens` from 131072 to 200000.
  - Documents Kimi 2-node and 3-node reduced-resource benchmarks while keeping the robust 4-node default.
  - Removes temporary experiment aliases for Kimi async/mm-data/Eagle3 and GLM FP8 variants.

- `README.md`
  - Replaces the old "GLM not recommended because eager is required" framing.
  - Adds updated throughput tables for GLM BF16, Kimi, and GLM FP8 caveats.
  - Clarifies that `GLM-5.1-FP8` is not the selected config on this environment.

- `tests/test_config.py`
  - Updates the serve-config assertions so tests now pin GLM's no-eager default.

## Validation

- `uv run --no-sync pytest tests/test_config.py`
- Served and benchmarked:
  - GLM-5.1 BF16 no-eager: healthy and generated successfully.
  - GLM-5.1 BF16 no-eager on 4 nodes: healthy, same single-request speed, higher aggregate throughput, worse GPU efficiency than the 3-node default.
  - GLM-5.1-FP8 eager, no MTP / MTP=1 / MTP=3: healthy but slow.
  - GLM-5.1-FP8 no-eager, shared and isolated caches: fails with `CUDA_ERROR_FILE_NOT_FOUND` in DeepGEMM FP8 warmup.
  - Kimi-K2.6 canonical / async / mm-data: healthy, effectively tied.
  - Kimi-K2.6 canonical on 2 and 3 nodes: healthy; short-prompt throughput tied 4 nodes, but full-context KV headroom is lower.
  - Kimi-K2.6 full one-shot CritPt sweep: `70/70` submission JSONs after the 200k output-token retry.

## Notes

The official GLM FP8 recipe likely needs the Docker/source stack from the recipe rather than our current pip wheel plus local DeepGEMM wheel. On the current environment, BF16 GLM no-eager is the practical default.

Made with [Cursor](https://cursor.com)