### PR TITLE
feat: enable 2M token budget default & fix retry classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,17 @@ Set API keys for the providers you want to use (in `.env` or as env vars):
 ```
 open_dirac [problem.yaml] [options]
 
-  problem.yaml                Problem YAML file (default: problems/critpt/quantum_error_correction_main.yaml)
-  --model MODEL               LLM model key (default: from config.default.yaml, resolved via models.yaml)
-  --replay DIR                Replay console log from a workspace (no run)
-  --max-iterations N          Max loop iterations (default: see config.default.yaml)
-  --workspace-dir DIR         Workspace directory (default: workspaces/YYYYMMDD_HHMMSS_<problem>)
-  --resume DIR                Resume from existing workspace if DIR exists
-  --config FILE               Path to config YAML file (overrides defaults)
+  problem.yaml                    Problem YAML file
+  --model MODEL                   LLM model key (default: from config.default.yaml)
+  --replay DIR                    Replay console log from a workspace (no run)
+  --max-iterations N              Max loop iterations (default: 40)
+  --max-wall-seconds S            Wall-clock budget in seconds (0 = disabled, default: 0)
+  --max-total-output-tokens N     Cumulative output token budget (0 = disabled, default: 2000000)
+  --max-cost-usd USD              Cumulative cost cap in USD (0 = disabled, default: 0)
+  --best-guess-every-n N          Write BEST_GUESS.md every N iterations (0 = disabled, default: 10)
+  --workspace-dir DIR             Workspace directory (default: auto-generated)
+  --resume DIR                    Resume from existing workspace
+  --config FILE                   Path to config YAML file (overrides defaults)
 ```
 
 ### Configuration
@@ -79,7 +83,7 @@ The `max_output_tokens` budget per LLM call is **not** a general default — it 
 
 #### Soft-exit triggers
 
-In addition to `max_iterations`, the loop accepts three optional cumulative budgets — `max_wall_seconds`, `max_total_output_tokens`, and `max_cost_usd` (USD, computed from `models.yaml` pricing). All default to `0` (disabled). When any gate fires, the loop finishes its current iteration and a forced formatter writes a best-effort `ANSWER.md` (status: `partially_complete`); the triggering gate name appears in the final commit message. `max_wall_seconds` is per-`run()` invocation — it restarts on resume; the token and cost budgets are cumulative across resumes.
+In addition to `max_iterations`, the loop accepts three optional cumulative budgets — `max_wall_seconds`, `max_total_output_tokens`, and `max_cost_usd` (USD, computed from `models.yaml` pricing). `max_total_output_tokens` defaults to 2M tokens, making benchmarks comparable across models with different inference speeds (e.g. Kimi at 33 t/s vs Gemini at 200 t/s); the other two default to `0` (disabled). When any gate fires, the loop finishes its current iteration and a forced formatter writes a best-effort `ANSWER.md` (status: `partially_complete`); the triggering gate name appears in the final commit message. `max_wall_seconds` is per-`run()` invocation — it restarts on resume; the token and cost budgets are cumulative across resumes.
 
 To grant more budget after a soft-exit and continue the run, delete `ANSWER.md` and re-run with `--resume`. `ANSWER.md` is the canonical "this run is done" signal: present ⇒ resume refuses; absent ⇒ resume resets `partially_complete` to `in_progress` and continues from the last committed iteration.
 
@@ -340,9 +344,10 @@ Kimi-K2.6 also fits on fewer nodes. With the same canonical flags:
 | 3 | ~92 tok/s | ~547 tok/s | ~920 tok/s | 7.48× at 262k context | Almost enough for 8-way full-context use, still less headroom than 4 nodes. |
 | 4 | ~92 tok/s | ~558 tok/s | ~920 tok/s | 11.12× at 262k context | Chosen default for robust 8-way CritPt runs. |
 
-Kimi's `max_output_tokens` is intentionally `200000`. The old 131k cap left
-five hard one-shot CritPt problems without parseable answer code; rerunning just
-those with the higher cap completed the full 70/70 submission set.
+Kimi's `max_output_tokens` is `65536` per call. With `max_tokens_retries: 2`,
+the model can continue truncated responses across up to 3 calls (~195k effective
+tokens). The previous 200k cap allowed single LLM rounds to generate 150k+
+reasoning tokens (76 min at 33 t/s), leaving no headroom for iterations.
 
 Kimi also needs vLLM's `kimi_k2` tool and reasoning parsers for the full
 OpenDirac agent harness. The one-shot harness works without tools, but the

--- a/scripts/run_critpt_open_dirac.py
+++ b/scripts/run_critpt_open_dirac.py
@@ -87,11 +87,11 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--timeout",
         type=int,
-        default=10800,
+        default=86400,
         help=(
-            "Per-problem wall-clock budget, in seconds (default: 10800). "
-            "Forwarded to the engine as --max-wall-seconds: when the "
-            "budget expires the engine soft-exits, runs the forced "
+            "Per-problem wall-clock budget, in seconds (default: 86400 = 24h "
+            "safety net). Forwarded to the engine as --max-wall-seconds: when "
+            "the budget expires the engine soft-exits, runs the forced "
             "formatter and writes a best-effort ANSWER.md. The runner "
             "does not hard-kill the subprocess."
         ),
@@ -514,9 +514,7 @@ async def run_one_problem(
             # --max-wall-seconds (forwarded from --timeout). When it
             # expires the engine soft-exits cleanly, so we just await
             # the subprocess to finish.
-            await asyncio.gather(
-                _stream_stdout(), _drain_stderr(), proc.wait()
-            )
+            await asyncio.gather(_stream_stdout(), _drain_stderr(), proc.wait())
             elapsed = time.monotonic() - start
             stats["api_retries"] = state["api_retries"]
 
@@ -630,7 +628,7 @@ async def run_batch(args: argparse.Namespace) -> int:
     print(f"  resume:    {n_resume} (continue interrupted run)", file=sys.stderr)
     print(f"  fresh:     {n_fresh} (new run)", file=sys.stderr)
     print(f"Concurrency: {args.concurrency}", file=sys.stderr)
-    print(f"Timeout:     {args.timeout}s per problem", file=sys.stderr)
+    print(f"Timeout:     {args.timeout}s wall-clock per problem", file=sys.stderr)
     print(f"Output:      {output_dir}", file=sys.stderr)
     print("---", file=sys.stderr)
 

--- a/src/open_dirac/config.default.yaml
+++ b/src/open_dirac/config.default.yaml
@@ -82,8 +82,10 @@ pipeline_retry_max: 2
 # tracked).
 max_wall_seconds: 0
 # Cumulative output tokens across all agents for the whole workspace
-# (survives resume via MetricsTracker.load()).
-max_total_output_tokens: 0
+# (survives resume via MetricsTracker.load()). Default 2M tokens makes
+# benchmarks comparable across models with different inference speeds
+# (e.g. Kimi at 33 t/s vs Gemini at 200 t/s).
+max_total_output_tokens: 2000000
 # Cumulative estimated cost in USD, computed from input_cost/output_cost
 # in models.yaml.
 max_cost_usd: 0.0

--- a/src/open_dirac/engine.py
+++ b/src/open_dirac/engine.py
@@ -181,8 +181,7 @@ class OpenDirac:
             engine.research_state.status = "in_progress"
             engine._state.consecutive_termination_blocks = 0
             console.print(
-                "[dim]ANSWER.md absent on resume — status reset to "
-                "in_progress.[/dim]"
+                "[dim]ANSWER.md absent on resume — status reset to in_progress.[/dim]"
             )
 
         # 6. Reconstruct last critic iteration
@@ -844,10 +843,7 @@ class OpenDirac:
             if elapsed >= self.config.max_wall_seconds:
                 return "max_wall_seconds"
         if self.config.max_total_output_tokens > 0:
-            if (
-                self.metrics.total_output_tokens
-                >= self.config.max_total_output_tokens
-            ):
+            if self.metrics.total_output_tokens >= self.config.max_total_output_tokens:
                 return "max_total_output_tokens"
         if self.config.max_cost_usd > 0:
             cost = self.metrics.estimated_cost_usd(
@@ -1251,9 +1247,7 @@ class OpenDirac:
             self.formatter.run(fmt_task, self.iteration)
             rejection = self.formatter.rejection_reason
             if rejection:
-                console.print(
-                    f"[dim]  snapshot rejected: {rejection[:120]}[/dim]"
-                )
+                console.print(f"[dim]  snapshot rejected: {rejection[:120]}[/dim]")
             else:
                 console.print("[dim]  → BEST_GUESS.md written[/dim]")
             self.workspace.git_commit(

--- a/src/open_dirac/main.py
+++ b/src/open_dirac/main.py
@@ -68,10 +68,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--max-cost-usd",
         type=float,
         default=None,
-        help=(
-            "Cumulative estimated cost cap in USD (0 = disabled). "
-            "Survives resume."
-        ),
+        help=("Cumulative estimated cost cap in USD (0 = disabled). Survives resume."),
     )
     parser.add_argument(
         "--best-guess-every-n",
@@ -213,7 +210,6 @@ def _main_resume(args) -> None:
         value = getattr(args, key.replace("-", "_"), None)
         if value is not None:
             overrides[key] = value
-
     engine = OpenDirac.resume(workspace_path, config_overrides=overrides or None)
     engine.run()
 

--- a/src/open_dirac/models.yaml
+++ b/src/open_dirac/models.yaml
@@ -339,7 +339,7 @@ zai-org/GLM-5.1:
   env_key: VLLM_API_KEY
   input_cost: 0.0
   output_cost: 0.0
-  max_output_tokens: 131072
+  max_output_tokens: 65536
   reasoning_format: separate_field
   tool_mode: api
   serve:
@@ -440,10 +440,7 @@ moonshotai/Kimi-K2.6:
   env_key: VLLM_API_KEY
   input_cost: 0.0
   output_cost: 0.0
-  # The hardest CritPt one-shot problems hit the old 131k cap before emitting
-  # parseable answer code. Keep a small buffer under the 262k context window for
-  # prompts while giving the model room to finish long reasoning traces.
-  max_output_tokens: 200000
+  max_output_tokens: 65536
   reasoning_format: separate_field
   tool_mode: api
   serve:

--- a/src/open_dirac/providers/retry.py
+++ b/src/open_dirac/providers/retry.py
@@ -28,7 +28,6 @@ TRANSIENT_EXC_NAMES = {
     "BrokenPipeError",
     "APITimeoutError",
     "APIConnectionError",
-    "APIStatusError",
     "ServerError",
     "RemoteProtocolError",
 }
@@ -38,6 +37,7 @@ _PROVIDER_SIDE_400_PATTERNS = {
     "internal error",
     "backend error",
     "input validation",  # HuggingFace context-length / format rejection
+    "expecting",  # vLLM JSON parse failure ("Expecting ',' delimiter")
 }
 
 _CONTEXT_TOO_LONG_PATTERNS = (
@@ -225,8 +225,13 @@ def call_with_retry(
                 raise ContextTooLongError(exc) from exc
             if not is_transient(exc) or attempt == max_retries:
                 raise
-            # Provider-side 400s are deterministic — cap at 1 retry (2 attempts total)
-            if is_provider_side_400(exc) and attempt >= 1:
+            # Provider-side 400s are deterministic — cap at 1 retry (2 attempts total).
+            # Tool-call failures take priority: they're stochastic and get the full budget.
+            if (
+                is_provider_side_400(exc)
+                and not is_tool_call_failure(exc)
+                and attempt >= 1
+            ):
                 raise
             if on_retry is not None:
                 on_retry(exc, attempt, max_retries)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -63,6 +63,13 @@ class TestDefaults:
     def test_progress_check_interval_in_yaml_fields(self):
         assert "progress_check_interval" in _YAML_CONFIG_FIELDS
 
+    def test_max_total_output_tokens_default(self):
+        assert Config().max_total_output_tokens == 2_000_000
+        assert DEFAULTS["max_total_output_tokens"] == 2_000_000
+
+    def test_max_total_output_tokens_in_yaml_fields(self):
+        assert "max_total_output_tokens" in _YAML_CONFIG_FIELDS
+
 
 # ---------------------------------------------------------------------------
 # load_config_yaml
@@ -176,6 +183,20 @@ class TestBuildConfig:
         assert cfg.max_iterations == 50  # from YAML
         assert cfg.max_tokens == 128000  # tracks CLI-selected model
 
+    def test_max_total_output_tokens_cli_override(self):
+        args = Namespace(
+            config=None,
+            model=None,
+            max_iterations=None,
+            max_wall_seconds=None,
+            max_total_output_tokens=500_000,
+            max_cost_usd=None,
+            best_guess_every_n=None,
+            workspace_dir=None,
+        )
+        cfg = build_config(args)
+        assert cfg.max_total_output_tokens == 500_000
+
     def test_max_tokens_not_settable_via_yaml(self, tmp_path):
         """max_tokens is ignored in config YAML (models.yaml is the source)."""
         cfg_file = tmp_path / "config.yaml"
@@ -206,7 +227,7 @@ class TestModelRegistryResolution:
         cfg = Config(model="zai-org/GLM-5.1")
         assert cfg.provider == "vllm"
         assert cfg.model_id == "zai-org/GLM-5.1"
-        assert cfg.max_tokens == 131072
+        assert cfg.max_tokens == 65536
         assert cfg.reasoning["reasoning_format"] == "separate_field"
         assert cfg.reasoning["tool_mode"] == "api"
 
@@ -214,7 +235,7 @@ class TestModelRegistryResolution:
         cfg = Config(model="moonshotai/Kimi-K2.6")
         assert cfg.provider == "vllm"
         assert cfg.model_id == "moonshotai/Kimi-K2.6"
-        assert cfg.max_tokens == 200000
+        assert cfg.max_tokens == 65536
         assert cfg.reasoning["reasoning_format"] == "separate_field"
         assert cfg.reasoning["tool_mode"] == "api"
 
@@ -375,6 +396,14 @@ class TestMainParser:
         assert args.model is None
         assert args.max_iterations is None
         assert args.workspace_dir is None
+        assert args.max_total_output_tokens is None
+
+    def test_max_total_output_tokens_flag(self):
+        from open_dirac.main import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["p.yaml", "--max-total-output-tokens", "500000"])
+        assert args.max_total_output_tokens == 500000
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_llm_retry.py
+++ b/tests/test_llm_retry.py
@@ -268,6 +268,16 @@ class FakePostProcessorResponseError(Exception):
         super().__init__("Encountered Exception during gpt oss post processor")
 
 
+class FakeJsonParseError400(Exception):
+    """Mimics vLLM 400 with JSON parse failure ('Expecting delimiter')."""
+
+    def __init__(self):
+        self.status_code = 400
+        super().__init__(
+            "BadRequestError: Expecting ',' delimiter: line 1 column 3253 (char 3252)"
+        )
+
+
 @pytest.mark.parametrize(
     "exc",
     [
@@ -275,6 +285,7 @@ class FakePostProcessorResponseError(Exception):
         FakeInternalError400(),
         FakeBackendError400(),
         FakePostProcessorResponseError(),
+        FakeJsonParseError400(),
     ],
 )
 def test_is_provider_side_400_true(exc):
@@ -298,6 +309,68 @@ def test_is_provider_side_400_false(exc):
 def test_is_transient_true_for_provider_side_400():
     """Provider-side 400s are classified as transient (retryable, but capped)."""
     assert _is_transient(FakePostProcessorError()) is True
+
+
+def test_json_parse_400_capped_at_2_attempts():
+    """vLLM JSON parse 400s are provider-side 400s, capped at 2 attempts total."""
+    provider = MagicMock()
+    provider.call.side_effect = FakeJsonParseError400()
+    config = _make_config(api_retry_max=10)
+
+    with patch("open_dirac.providers.retry.time.sleep"):
+        with pytest.raises(FakeJsonParseError400):
+            _call_provider_with_retry(
+                provider,
+                config,
+                model="m",
+                max_tokens=100,
+                system="s",
+                messages=[],
+            )
+
+    assert provider.call.call_count == 2
+
+
+def test_plain_400_not_transient():
+    """A plain HTTP 400 without any matching pattern is NOT retried."""
+    assert _is_transient(FakeHTTPError(400)) is False
+
+
+class FakeToolCallWithExpecting(Exception):
+    """Tool call failure whose message also contains 'expecting' (overlap case)."""
+
+    def __init__(self):
+        self.status_code = 400
+        super().__init__(
+            "BadRequestError: tool_use_failed - "
+            "Failed to parse tool call arguments: Expecting ',' delimiter"
+        )
+
+
+def test_tool_call_with_expecting_gets_full_retries():
+    """Tool-call failures that overlap with 'expecting' pattern get full retry budget."""
+    exc = FakeToolCallWithExpecting()
+    assert _is_tool_call_failure(exc) is True
+    assert _is_provider_side_400(exc) is True  # both match
+    assert _is_transient(exc) is True
+
+    provider = MagicMock()
+    provider.call.side_effect = FakeToolCallWithExpecting()
+    config = _make_config(api_retry_max=5)
+
+    with patch("open_dirac.providers.retry.time.sleep"):
+        with pytest.raises(FakeToolCallWithExpecting):
+            _call_provider_with_retry(
+                provider,
+                config,
+                model="m",
+                max_tokens=100,
+                system="s",
+                messages=[],
+            )
+
+    # Should use full budget (6 attempts), NOT capped at 2
+    assert provider.call.call_count == 6
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Set `max_total_output_tokens` default to 2,000,000** (was 0/disabled). This makes benchmarks comparable across models with different inference speeds — Kimi at 33 t/s gets the same token budget as Gemini at 200 t/s, rather than being penalized by wall-clock time. The `max_iterations` (40) guard still applies independently.
- **Raise `run_critpt_open_dirac.py` wall-clock timeout to 24h** (was 3h). The token budget is now the primary stopping criterion; the wall-clock timeout is a safety net.
- **Cap per-call `max_output_tokens` for Kimi-K2.6 and vLLM GLM-5.1 to 65,536** (down from 200k/131k). Prevents single LLM rounds from burning 150k+ reasoning tokens (76 min at 33 t/s). With `max_tokens_retries: 2`, effective cap is ~195k via continuations.
- **Fix retry classification** in `retry.py`:
  - Add `"expecting"` to `_PROVIDER_SIDE_400_PATTERNS` — caps vLLM JSON parse error retries at 2 attempts instead of 10 (~7 min saved per exhaustion event).
  - Remove `APIStatusError` from `TRANSIENT_EXC_NAMES` — stops blanket retry of all HTTP errors. The status-code check (`TRANSIENT_STATUS_CODES`) already handles truly transient server errors (429, 500, 502, etc.).

## Test plan

- [x] All 1329 tests pass
- [x] `ruff check` and `ruff format` clean
- [x] Verify `Config().max_total_output_tokens == 2_000_000`
- [x] Verify `Config(model="moonshotai/Kimi-K2.6").max_tokens == 65536`
- [x] Verify JSON parse 400 errors are capped at 2 attempts
- [x] Verify plain HTTP 400 errors are not retried

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default termination budgeting to stop runs by cumulative output tokens (now 2M by default) and adjusts retry classification for certain 400s, which can materially alter run length, cost, and failure behavior in benchmarks.
> 
> **Overview**
> This PR changes the default soft-exit behavior by enabling a **2,000,000 cumulative `max_total_output_tokens` budget** (previously disabled), keeping wall-clock and cost gates off by default and updating docs/tests accordingly.
> 
> It also makes benchmark-running safer/more consistent by raising the CritPt runner’s per-problem wall-clock safety timeout to **24h**, and caps vLLM `zai-org/GLM-5.1` and `moonshotai/Kimi-K2.6` per-call `max_output_tokens` to **65,536** (relying on `max_tokens_retries` for continuation).
> 
> Retry logic is tightened by treating vLLM JSON-parse 400s ("expecting …") as provider-side 400s (capped retries) and removing blanket transient classification for `APIStatusError`, with new tests covering the updated behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d7e2737290bd89f157b68d6c3046123a1113d16. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->