### PR TITLE
fix: handle malformed JSON in vLLM tool call arguments

### DIFF
--- a/serve/full_eval.slurm
+++ b/serve/full_eval.slurm
@@ -139,16 +139,23 @@ fi
 cd "$REPO_ROOT"
 
 LB_PID=""
+RUNNER_EXIT=1  # assume failure until proven otherwise
 cleanup() {
   if [[ -n "$LB_PID" ]]; then
     echo "Shutting down load balancer (PID $LB_PID)..."
     kill "$LB_PID" 2>/dev/null || true
     wait "$LB_PID" 2>/dev/null || true
   fi
-  # Cancel serve jobs unless --keep-serves was passed.
-  if [[ -z "$KEEP_SERVES" && ${#SERVE_JOBS[@]} -gt 0 ]]; then
-    echo "Cancelling ${#SERVE_JOBS[@]} serve job(s): ${SERVE_JOBS[*]}"
-    scancel "${SERVE_JOBS[@]}" 2>/dev/null || true
+  # Cancel serve jobs when: (a) --keep-serves was NOT passed, or
+  # (b) --keep-serves was passed but the runner finished successfully
+  #     (exit 0 = natural completion, no need to keep serves for reruns).
+  if [[ ${#SERVE_JOBS[@]} -gt 0 ]]; then
+    if [[ -z "$KEEP_SERVES" || "$RUNNER_EXIT" -eq 0 ]]; then
+      echo "Cancelling ${#SERVE_JOBS[@]} serve job(s): ${SERVE_JOBS[*]}"
+      scancel "${SERVE_JOBS[@]}" 2>/dev/null || true
+    else
+      echo "Keeping ${#SERVE_JOBS[@]} serve job(s) alive (--keep-serves, runner exit=$RUNNER_EXIT)"
+    fi
   fi
 }
 trap cleanup EXIT
@@ -206,9 +213,9 @@ if [[ "$RUNNER" == "opendirac" ]]; then
     "${CONFIG_ARG[@]}" \
     "${RESUME_ARG[@]}" \
     "${FRESH_ARG[@]}" \
-    "${WS_ARG[@]}"
+    "${WS_ARG[@]}" && RUNNER_EXIT=0 || RUNNER_EXIT=$?
 else
   uv run --no-sync python scripts/run_critpt_oneshot.py \
     --model "$MODEL_KEY" --concurrency "$CONCURRENCY" --timeout 3600 \
-    "${RESUME_ARG[@]}"
+    "${RESUME_ARG[@]}" && RUNNER_EXIT=0 || RUNNER_EXIT=$?
 fi

--- a/src/open_dirac/providers/retry.py
+++ b/src/open_dirac/providers/retry.py
@@ -38,6 +38,9 @@ _PROVIDER_SIDE_400_PATTERNS = {
     "backend error",
     "input validation",  # HuggingFace context-length / format rejection
     "expecting",  # vLLM JSON parse failure ("Expecting ',' delimiter")
+    "invalid \\escape",  # vLLM JSON parse failure ("Invalid \escape")
+    "unterminated string",  # vLLM JSON parse failure ("Unterminated string starting at")
+    "extra data",  # vLLM JSON parse failure ("Extra data: line 1 column ...")
 }
 
 _CONTEXT_TOO_LONG_PATTERNS = (
@@ -109,21 +112,38 @@ def extract_status_code(exc: Exception) -> int | None:
     return None
 
 
+_TOOL_CALL_FAILURE_PATTERNS = (
+    "tool_use_failed",
+    "failed to parse tool call arguments",
+    "output_parse_failed",  # HF backend can't parse non-tool output
+    "tool choice",  # "Tool choice is none, but model called a tool"
+)
+
+# JSON parse errors from vLLM when the model produces malformed tool call
+# arguments. These are stochastic (the model may produce valid JSON on retry)
+# and should get the full retry budget, not the capped provider-side 400 budget.
+_JSON_PARSE_400_PATTERNS = (
+    "invalid \\escape",
+    "unterminated string",
+    "extra data",
+    "expecting",  # "Expecting ',' delimiter", "Expecting value", etc.
+)
+
+
 def is_tool_call_failure(exc: Exception) -> bool:
     """Return True if *exc* is a tool-call generation failure.
 
-    Covers both JSON parse failures and OSS models ignoring tool_choice=none.
+    Covers both explicit tool-call parse failures and vLLM JSON parse
+    errors in model-generated tool arguments (Invalid \\escape, etc.).
     """
     msg = str(exc).lower()
-    return any(
-        p in msg
-        for p in (
-            "tool_use_failed",
-            "failed to parse tool call arguments",
-            "output_parse_failed",  # HF backend can't parse non-tool output
-            "tool choice",  # "Tool choice is none, but model called a tool"
-        )
-    )
+    if any(p in msg for p in _TOOL_CALL_FAILURE_PATTERNS):
+        return True
+    # vLLM JSON parse 400s from malformed tool call arguments
+    status = extract_status_code(exc)
+    if status == 400 and any(p in msg for p in _JSON_PARSE_400_PATTERNS):
+        return True
+    return False
 
 
 def is_provider_side_400(exc: Exception) -> bool:

--- a/src/open_dirac/providers/vllm.py
+++ b/src/open_dirac/providers/vllm.py
@@ -377,17 +377,44 @@ class VLLMProvider(LLMProvider):
     # Message formatting
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _sanitize_arguments(args: str) -> str:
+        """Ensure tool call arguments are valid JSON before re-sending.
+
+        vLLM rejects requests containing ``function.arguments`` that are not
+        parseable JSON, returning a 400.  When the model produces malformed
+        JSON (invalid escapes, unterminated strings, etc.) we attempt a
+        best-effort repair; if that fails, we wrap the raw string as
+        ``{"raw": "<escaped>"}``.
+        """
+        if not args:
+            return "{}"
+        try:
+            json.loads(args)
+            return args
+        except json.JSONDecodeError:
+            pass
+        # Best-effort: the most common issue is unescaped backslashes.
+        try:
+            fixed = args.replace("\\", "\\\\")
+            json.loads(fixed)
+            return fixed
+        except json.JSONDecodeError:
+            pass
+        return json.dumps({"raw": args})
+
     def format_assistant_message(self, raw_content: object) -> dict:
         msg = {"role": "assistant", "content": raw_content.content}
         if raw_content.tool_calls:
-            # Structured tool calls (api mode) — include in message
             msg["tool_calls"] = [
                 {
                     "id": tc.id,
                     "type": "function",
                     "function": {
                         "name": tc.function.name,
-                        "arguments": tc.function.arguments,
+                        "arguments": self._sanitize_arguments(
+                            tc.function.arguments
+                        ),
                     },
                 }
                 for tc in raw_content.tool_calls

--- a/src/open_dirac/providers/vllm.py
+++ b/src/open_dirac/providers/vllm.py
@@ -412,9 +412,7 @@ class VLLMProvider(LLMProvider):
                     "type": "function",
                     "function": {
                         "name": tc.function.name,
-                        "arguments": self._sanitize_arguments(
-                            tc.function.arguments
-                        ),
+                        "arguments": self._sanitize_arguments(tc.function.arguments),
                     },
                 }
                 for tc in raw_content.tool_calls

--- a/tests/test_llm_retry.py
+++ b/tests/test_llm_retry.py
@@ -213,9 +213,7 @@ class FakeExtraData400(Exception):
 
     def __init__(self):
         self.status_code = 400
-        super().__init__(
-            "BadRequestError: Extra data: line 1 column 336 (char 335)"
-        )
+        super().__init__("BadRequestError: Extra data: line 1 column 336 (char 335)")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_llm_retry.py
+++ b/tests/test_llm_retry.py
@@ -178,6 +178,60 @@ def test_is_tool_call_failure_false_on_regular_400():
     assert _is_tool_call_failure(FakeHTTPError(400)) is False
 
 
+class FakeJsonParseError400(Exception):
+    """Mimics vLLM 400 with JSON parse failure ('Expecting delimiter')."""
+
+    def __init__(self):
+        self.status_code = 400
+        super().__init__(
+            "BadRequestError: Expecting ',' delimiter: line 1 column 3253 (char 3252)"
+        )
+
+
+class FakeInvalidEscape400(Exception):
+    """Mimics vLLM 400 with invalid JSON escape in tool call arguments."""
+
+    def __init__(self):
+        self.status_code = 400
+        super().__init__(
+            "BadRequestError: Invalid \\escape: line 1 column 7340 (char 7339)"
+        )
+
+
+class FakeUnterminatedString400(Exception):
+    """Mimics vLLM 400 with unterminated string in tool call arguments."""
+
+    def __init__(self):
+        self.status_code = 400
+        super().__init__(
+            "BadRequestError: Unterminated string starting at: line 1 column 10 (char 9)"
+        )
+
+
+class FakeExtraData400(Exception):
+    """Mimics vLLM 400 with extra data in tool call arguments."""
+
+    def __init__(self):
+        self.status_code = 400
+        super().__init__(
+            "BadRequestError: Extra data: line 1 column 336 (char 335)"
+        )
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        FakeInvalidEscape400(),
+        FakeUnterminatedString400(),
+        FakeExtraData400(),
+        FakeJsonParseError400(),
+    ],
+)
+def test_is_tool_call_failure_json_parse_400(exc):
+    """vLLM JSON parse 400s from malformed tool call arguments are tool-call failures."""
+    assert _is_tool_call_failure(exc) is True
+
+
 def test_is_transient_true_for_tool_call_failure():
     """_is_transient returns True for tool_use_failed errors (stochastic retry)."""
     assert _is_transient(FakeToolCallFailure()) is True
@@ -268,16 +322,6 @@ class FakePostProcessorResponseError(Exception):
         super().__init__("Encountered Exception during gpt oss post processor")
 
 
-class FakeJsonParseError400(Exception):
-    """Mimics vLLM 400 with JSON parse failure ('Expecting delimiter')."""
-
-    def __init__(self):
-        self.status_code = 400
-        super().__init__(
-            "BadRequestError: Expecting ',' delimiter: line 1 column 3253 (char 3252)"
-        )
-
-
 @pytest.mark.parametrize(
     "exc",
     [
@@ -286,6 +330,9 @@ class FakeJsonParseError400(Exception):
         FakeBackendError400(),
         FakePostProcessorResponseError(),
         FakeJsonParseError400(),
+        FakeInvalidEscape400(),
+        FakeUnterminatedString400(),
+        FakeExtraData400(),
     ],
 )
 def test_is_provider_side_400_true(exc):
@@ -311,11 +358,11 @@ def test_is_transient_true_for_provider_side_400():
     assert _is_transient(FakePostProcessorError()) is True
 
 
-def test_json_parse_400_capped_at_2_attempts():
-    """vLLM JSON parse 400s are provider-side 400s, capped at 2 attempts total."""
+def test_json_parse_400_gets_full_retries():
+    """vLLM JSON parse 400s are tool-call failures and get the full retry budget."""
     provider = MagicMock()
     provider.call.side_effect = FakeJsonParseError400()
-    config = _make_config(api_retry_max=10)
+    config = _make_config(api_retry_max=5)
 
     with patch("open_dirac.providers.retry.time.sleep"):
         with pytest.raises(FakeJsonParseError400):
@@ -328,7 +375,8 @@ def test_json_parse_400_capped_at_2_attempts():
                 messages=[],
             )
 
-    assert provider.call.call_count == 2
+    # Tool-call failures get the full budget (6 attempts), not capped at 2
+    assert provider.call.call_count == 6
 
 
 def test_plain_400_not_transient():

--- a/tests/test_vllm_provider.py
+++ b/tests/test_vllm_provider.py
@@ -375,3 +375,34 @@ class TestPrepareMessages:
         messages = [{"role": "user", "content": "hello"}]
         result = provider.prepare_messages(messages)
         assert result == messages
+
+
+# ---------------------------------------------------------------------------
+# _sanitize_arguments — ensure tool call args are valid JSON before re-send
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeArguments:
+    """Tests for VLLMProvider._sanitize_arguments()."""
+
+    def test_valid_json_passthrough(self):
+        assert VLLMProvider._sanitize_arguments('{"code": "x"}') == '{"code": "x"}'
+
+    def test_empty_string_returns_empty_object(self):
+        assert VLLMProvider._sanitize_arguments("") == "{}"
+
+    def test_none_string_returns_empty_object(self):
+        assert VLLMProvider._sanitize_arguments(None) == "{}"
+
+    def test_invalid_escape_wrapped(self):
+        bad = '{"code": "foo\\xbar"}'
+        result = VLLMProvider._sanitize_arguments(bad)
+        import json
+        json.loads(result)  # must not raise
+
+    def test_unterminated_string_wrapped(self):
+        bad = '{"code": "hello'
+        result = VLLMProvider._sanitize_arguments(bad)
+        import json
+        parsed = json.loads(result)
+        assert "raw" in parsed

--- a/tests/test_vllm_provider.py
+++ b/tests/test_vllm_provider.py
@@ -398,11 +398,13 @@ class TestSanitizeArguments:
         bad = '{"code": "foo\\xbar"}'
         result = VLLMProvider._sanitize_arguments(bad)
         import json
+
         json.loads(result)  # must not raise
 
     def test_unterminated_string_wrapped(self):
         bad = '{"code": "hello'
         result = VLLMProvider._sanitize_arguments(bad)
         import json
+
         parsed = json.loads(result)
         assert "raw" in parsed


### PR DESCRIPTION
## Problem

When serving Kimi-K2.6 via vLLM, the model occasionally generates malformed JSON in tool call arguments (invalid `\escape` sequences, unterminated strings, extra trailing data). This causes two issues:

1. **vLLM rejects re-sent messages** containing the malformed `function.arguments`, returning a 400 that kills the conversation.
2. **These 400s were classified as deterministic provider-side errors**, capped at 2 retry attempts — but they're actually stochastic (the model may produce valid JSON on retry) and should get the full retry budget.

Additionally, `full_eval.slurm` did not properly cancel serve jobs on successful completion when `--keep-serves` was passed.

## Solution

- **`providers/vllm.py`**: Added `_sanitize_arguments()` that repairs or wraps malformed JSON before re-sending tool call arguments in conversation history.
- **`providers/retry.py`**: Classified vLLM JSON parse 400s (`Invalid \escape`, `Unterminated string`, `Extra data`, `Expecting`) as tool-call failures, granting the full retry budget instead of capping at 2 attempts.
- **`serve/full_eval.slurm`**: Captures runner exit code; cancels serve jobs on successful completion even with `--keep-serves` (the flag now only preserves serves on failure/crash for manual rerun).

## Testing

- Added `TestSanitizeArguments` in `test_vllm_provider.py` covering valid JSON passthrough, empty input, invalid escapes, and unterminated strings.
- Added parameterized tests in `test_llm_retry.py` verifying the new error patterns are classified as both `is_provider_side_400` and `is_tool_call_failure`.
- Updated `test_json_parse_400_gets_full_retries` to confirm 6 attempts (full budget) instead of the previous 2.
- All 117 tests pass.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes LLM retry classification and message formatting for vLLM tool calls; mistakes could increase retry loops or alter tool-call replay, but scope is limited and covered by tests.
> 
> **Overview**
> Improves robustness of vLLM tool calling when models emit malformed JSON in `function.arguments` by **sanitizing/repairing arguments** before replaying prior tool calls, falling back to wrapping raw strings as JSON.
> 
> Updates retry classification so vLLM JSON-parse HTTP 400s (e.g. *invalid escape*, *unterminated string*, *extra data*, *expecting*) are treated as **stochastic tool-call failures** and receive the full retry budget instead of the provider-side 400 cap, with expanded tests verifying classification and retry counts.
> 
> Adjusts `serve/full_eval.slurm` cleanup behavior to track the runner exit code and **only keep serve jobs alive on failure** when `--keep-serves` is set; successful runs now cancel serves as normal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ed4a4cec4448b1448353c9d9ac777f3f1ca3427. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->