### PR TITLE
feat: two-stage reasoning compaction and per-agent token budgets

### DIFF
--- a/src/open_dirac/config.default.yaml
+++ b/src/open_dirac/config.default.yaml
@@ -66,6 +66,29 @@ parse_retries: 2
 # turn and asks the model to continue from where it stopped.
 max_tokens_retries: 2
 
+# --- Reasoning compaction ---
+# Number of "continue" attempts when reasoning fills the entire output
+# budget without producing visible answer text ("reasoning starved").
+# Each attempt feeds the reasoning back as context and lets the model
+# keep thinking with a fresh budget. After all continue attempts are
+# exhausted, one final "force answer" attempt tells the model to stop
+# reasoning and produce its answer.  Total calls = retries + 1.
+max_compaction_retries: 2
+
+# --- Per-agent max output tokens ---
+# Override the model-level max_output_tokens for specific agents. Agents
+# not listed here use the model-level default. Useful for capping agents
+# that don't need deep reasoning (e.g. orchestrator, formatter) so they
+# fail fast instead of burning 15 min on a reasoning loop.
+agent_max_tokens:
+  orchestrator: 16384
+  formatter: 16384
+  computer: 65536
+  reviewer: 65536
+  deep_critic: 65536
+  planner: 65536
+  adjudicator: 65536
+
 # --- Pipeline retry ---
 # Max retries for mandatory pipeline stages (surveyor, planner).
 # These stages run before the main loop — if retries are exhausted,

--- a/src/open_dirac/core/config.py
+++ b/src/open_dirac/core/config.py
@@ -65,6 +65,8 @@ class Config:
     auto_expire_iterations: int = DEFAULTS["auto_expire_iterations"]
     parse_retries: int = DEFAULTS["parse_retries"]
     max_tokens_retries: int = DEFAULTS["max_tokens_retries"]
+    max_compaction_retries: int = DEFAULTS["max_compaction_retries"]
+    agent_max_tokens: dict = field(default_factory=lambda: dict(DEFAULTS["agent_max_tokens"]))
     pipeline_retry_max: int = DEFAULTS["pipeline_retry_max"]
     max_wall_seconds: float = DEFAULTS["max_wall_seconds"]
     max_total_output_tokens: int = DEFAULTS["max_total_output_tokens"]
@@ -78,6 +80,14 @@ class Config:
     input_cost: float = 0.0  # USD per million input tokens (from models.yaml)
     output_cost: float = 0.0  # USD per million output tokens (from models.yaml)
     reasoning: dict = field(default_factory=dict)  # provider-specific reasoning params
+
+    def max_tokens_for_agent(self, agent_name: str) -> int:
+        """Return the max output tokens for a specific agent.
+
+        Falls back to the model-level ``max_tokens`` when no per-agent
+        override is configured.
+        """
+        return self.agent_max_tokens.get(agent_name, self.max_tokens)
 
     def to_dict(self) -> dict:
         """Serialize config fields for persistence (excludes sensitive/derived fields)."""
@@ -181,6 +191,8 @@ _YAML_CONFIG_FIELDS = frozenset(
         "auto_expire_iterations",
         "parse_retries",
         "max_tokens_retries",
+        "max_compaction_retries",
+        "agent_max_tokens",
         "pipeline_retry_max",
         "max_wall_seconds",
         "max_total_output_tokens",

--- a/src/open_dirac/core/config.py
+++ b/src/open_dirac/core/config.py
@@ -66,7 +66,9 @@ class Config:
     parse_retries: int = DEFAULTS["parse_retries"]
     max_tokens_retries: int = DEFAULTS["max_tokens_retries"]
     max_compaction_retries: int = DEFAULTS["max_compaction_retries"]
-    agent_max_tokens: dict = field(default_factory=lambda: dict(DEFAULTS["agent_max_tokens"]))
+    agent_max_tokens: dict = field(
+        default_factory=lambda: dict(DEFAULTS["agent_max_tokens"])
+    )
     pipeline_retry_max: int = DEFAULTS["pipeline_retry_max"]
     max_wall_seconds: float = DEFAULTS["max_wall_seconds"]
     max_total_output_tokens: int = DEFAULTS["max_total_output_tokens"]

--- a/src/open_dirac/llm.py
+++ b/src/open_dirac/llm.py
@@ -134,6 +134,167 @@ def _merge_responses(
     )
 
 
+_CONTINUE_PROMPT = (
+    "Your reasoning was cut off due to output length limits. "
+    "Here is your reasoning so far:\n\n"
+    "<reasoning>\n{reasoning}\n</reasoning>\n\n"
+    "Continue from where you left off."
+)
+
+_FORCE_ANSWER_PROMPT = (
+    "You have now had multiple attempts to reason about this problem and "
+    "each time your reasoning was cut off due to output length limits. "
+    "Here is your most recent reasoning:\n\n"
+    "<reasoning>\n{reasoning}\n</reasoning>\n\n"
+    "Based on ALL your reasoning so far, now produce your FINAL ANSWER. "
+    "Do NOT continue reasoning — go straight to the answer."
+)
+
+# Truncate reasoning to avoid blowing up the context window. ~100K chars
+# is roughly 25-30K tokens, which preserves the most important content.
+_MAX_COMPACTION_CHARS = 100_000
+
+
+def _truncate_reasoning(reasoning: str) -> str:
+    """Keep the first and last halves of reasoning within budget."""
+    if len(reasoning) <= _MAX_COMPACTION_CHARS:
+        return reasoning
+    half = _MAX_COMPACTION_CHARS // 2
+    return (
+        reasoning[:half]
+        + "\n\n[... reasoning truncated for length ...]\n\n"
+        + reasoning[-half:]
+    )
+
+
+def _compact_reasoning(
+    provider: LLMProvider,
+    starved_response: ProviderResponse,
+    config: Config,
+    *,
+    model: str,
+    max_tokens: int,
+    system: str,
+    messages: list[dict],
+    tools: list[dict] | None = None,
+    workspace_dir: str | Path = "",
+    iteration: int = 0,
+    agent_name: str = "",
+) -> ProviderResponse | None:
+    """Recover from reasoning starvation via two-stage compaction.
+
+    **Stage 1 — continue** (up to ``max_compaction_retries`` attempts):
+    Feed the truncated reasoning back as context and let the model keep
+    thinking with a fresh output budget.  This preserves answer quality
+    because the model can finish its derivation naturally.
+
+    **Stage 2 — force answer** (one final attempt):
+    If all continuation attempts also starve, force the model to produce
+    an answer from whatever reasoning it has accumulated.
+
+    Returns a merged ``ProviderResponse`` on success, or ``None`` if
+    compaction is not possible (no reasoning content, or all attempts
+    exhausted).
+    """
+    reasoning = starved_response.reasoning_content or ""
+    if not reasoning.strip():
+        return None
+
+    max_continue = config.max_compaction_retries
+    if max_continue <= 0:
+        return None
+
+    reasoning = _truncate_reasoning(reasoning)
+    merged = starved_response
+    total_attempts = max_continue + 1  # +1 for the force-answer stage
+
+    for attempt in range(1, total_attempts + 1):
+        is_force = attempt > max_continue
+        stage = "force_answer" if is_force else "continue"
+        prompt_template = _FORCE_ANSWER_PROMPT if is_force else _CONTINUE_PROMPT
+        compaction_msg = prompt_template.format(reasoning=reasoning)
+        comp_messages = list(messages) + [
+            {"role": "user", "content": compaction_msg},
+        ]
+
+        if workspace_dir:
+            log_scaffold_event(
+                workspace_dir,
+                iteration,
+                CC.LOOP_CONTROL,
+                f"reasoning_compaction_{stage}",
+                f"agent={agent_name}, attempt={attempt}/{total_attempts}, "
+                f"reasoning_chars={len(reasoning)}",
+            )
+        console.print(
+            f"[yellow]Reasoning starved — {stage} attempt "
+            f"{attempt}/{total_attempts} "
+            f"(feeding {len(reasoning):,} chars of reasoning back)[/yellow]"
+        )
+
+        call_kwargs = dict(
+            model=model,
+            max_tokens=max_tokens,
+            system=system,
+            messages=provider.prepare_messages(comp_messages),
+        )
+        if tools:
+            call_kwargs["tools"] = tools
+        try:
+            comp_response = _call_provider_with_retry(
+                provider,
+                config,
+                workspace_dir=workspace_dir,
+                iteration=iteration,
+                **call_kwargs,
+            )
+        except Exception as exc:
+            console.print(
+                f"[yellow]Compaction call failed: {type(exc).__name__}: {exc} "
+                f"— giving up[/yellow]"
+            )
+            return None
+
+        merged = _merge_responses(merged, comp_response)
+
+        comp_visible = strip_think_tags(comp_response.text or "")
+        if comp_visible.strip() or comp_response.tool_calls:
+            console.print(
+                f"[green]Compaction succeeded ({stage}, attempt {attempt}) — "
+                f"recovered {len(comp_visible)} chars of answer[/green]"
+            )
+            if workspace_dir:
+                log_scaffold_event(
+                    workspace_dir,
+                    iteration,
+                    CC.LOOP_CONTROL,
+                    "reasoning_compaction_success",
+                    f"agent={agent_name}, stage={stage}, attempt={attempt}, "
+                    f"answer_chars={len(comp_visible)}",
+                )
+            return merged
+
+        # Still starved — update reasoning for next attempt
+        new_reasoning = comp_response.reasoning_content or ""
+        if new_reasoning.strip():
+            reasoning = _truncate_reasoning(new_reasoning)
+
+    if workspace_dir:
+        log_scaffold_event(
+            workspace_dir,
+            iteration,
+            CC.LOOP_CONTROL,
+            "reasoning_compaction_exhausted",
+            f"agent={agent_name}, attempts={total_attempts}",
+        )
+    console.print(
+        f"[red]Compaction exhausted ({total_attempts} attempts: "
+        f"{max_continue} continue + 1 force) "
+        f"— reasoning starvation unrecoverable[/red]"
+    )
+    return None
+
+
 def continue_on_max_tokens(
     provider: LLMProvider,
     first_response: ProviderResponse,
@@ -197,6 +358,23 @@ def continue_on_max_tokens(
                 "max_tokens_reasoning_starved",
                 f"agent={agent_name}, output_tokens={first_response.output_tokens}",
             )
+        # Attempt reasoning compaction: feed the truncated reasoning back
+        # and ask the model to continue from where it left off.
+        compacted = _compact_reasoning(
+            provider,
+            first_response,
+            config,
+            model=model,
+            max_tokens=max_tokens,
+            system=system,
+            messages=messages,
+            tools=tools,
+            workspace_dir=workspace_dir,
+            iteration=iteration,
+            agent_name=agent_name,
+        )
+        if compacted is not None:
+            return compacted
         return first_response
 
     max_retries = config.max_tokens_retries
@@ -324,6 +502,7 @@ def call_llm(
     log_path = _allocate_log_path(config, agent_name, iteration)
     _write_preliminary_log(log_path, system, user_content)
 
+    agent_max_tokens = config.max_tokens_for_agent(agent_name)
     initial_messages = [{"role": "user", "content": user_content}]
     start = time.time()
     resp = _call_provider_with_retry(
@@ -332,7 +511,7 @@ def call_llm(
         workspace_dir=config.workspace_dir,
         iteration=iteration,
         model=config.model_id,
-        max_tokens=config.max_tokens,
+        max_tokens=agent_max_tokens,
         system=system,
         messages=initial_messages,
     )
@@ -343,7 +522,7 @@ def call_llm(
             resp,
             config,
             model=config.model_id,
-            max_tokens=config.max_tokens,
+            max_tokens=agent_max_tokens,
             system=system,
             messages=initial_messages,
             workspace_dir=config.workspace_dir,
@@ -419,6 +598,7 @@ def call_llm_continuation(
         )
     provider = _get_provider(config)
     prepared = provider.prepare_messages(list(messages))
+    agent_max_tokens = config.max_tokens_for_agent(agent_name)
 
     start = time.time()
     resp = _call_provider_with_retry(
@@ -427,7 +607,7 @@ def call_llm_continuation(
         workspace_dir=config.workspace_dir,
         iteration=iteration,
         model=config.model_id,
-        max_tokens=config.max_tokens,
+        max_tokens=agent_max_tokens,
         system=system,
         messages=prepared,
     )
@@ -437,7 +617,7 @@ def call_llm_continuation(
             resp,
             config,
             model=config.model_id,
-            max_tokens=config.max_tokens,
+            max_tokens=agent_max_tokens,
             system=system,
             messages=list(messages),
             workspace_dir=config.workspace_dir,
@@ -577,6 +757,7 @@ def run_agent_loop(
 ) -> AgentResult:
     """Run a tool-use agent loop until end_turn, max_rounds, or max_tokens."""
     provider = _get_provider(config)
+    agent_max_tokens = config.max_tokens_for_agent(agent_name)
     messages = [{"role": "user", "content": user_content}]
 
     all_tool_calls: list[ToolCall] = []
@@ -646,7 +827,7 @@ def run_agent_loop(
                 workspace_dir=config.workspace_dir,
                 iteration=iteration,
                 model=config.model_id,
-                max_tokens=config.max_tokens,
+                max_tokens=agent_max_tokens,
                 system=system,
                 messages=provider.prepare_messages(messages),
                 tools=active_tools,
@@ -710,7 +891,7 @@ def run_agent_loop(
                 resp,
                 config,
                 model=config.model_id,
-                max_tokens=config.max_tokens,
+                max_tokens=agent_max_tokens,
                 system=system,
                 messages=messages,
                 tools=active_tools,
@@ -1187,7 +1368,7 @@ def run_agent_loop(
     for _forced_attempt in range(_forced_max_retries + 1):
         _forced_call_kwargs = dict(
             model=config.model_id,
-            max_tokens=config.max_tokens,
+            max_tokens=agent_max_tokens,
             system=system,  # UNCHANGED system prompt
             messages=provider.prepare_messages(messages),
         )
@@ -1478,6 +1659,15 @@ def _write_conversation_log(
         )
     resp_attrs += f' duration="{resp.duration:.1f}s" stop="{resp.stop_reason}"'
 
+    reasoning_section = ""
+    if resp.reasoning_content:
+        rc_len = len(resp.reasoning_content)
+        reasoning_section = (
+            f'\n<REASONING chars="{rc_len}">\n'
+            f"{resp.reasoning_content}\n"
+            f"</REASONING>\n"
+        )
+
     content = f"""<SYSTEM_PROMPT chars="{len(system)}">
 {system}
 </SYSTEM_PROMPT>
@@ -1489,7 +1679,7 @@ def _write_conversation_log(
 <LLM_RESPONSE {resp_attrs}>
 {resp.text}
 </LLM_RESPONSE>
-"""
+{reasoning_section}"""
     try:
         log_path.write_text(content)
     except OSError:

--- a/src/open_dirac/llm.py
+++ b/src/open_dirac/llm.py
@@ -1663,9 +1663,7 @@ def _write_conversation_log(
     if resp.reasoning_content:
         rc_len = len(resp.reasoning_content)
         reasoning_section = (
-            f'\n<REASONING chars="{rc_len}">\n'
-            f"{resp.reasoning_content}\n"
-            f"</REASONING>\n"
+            f'\n<REASONING chars="{rc_len}">\n{resp.reasoning_content}\n</REASONING>\n'
         )
 
     content = f"""<SYSTEM_PROMPT chars="{len(system)}">

--- a/src/open_dirac/llm.py
+++ b/src/open_dirac/llm.py
@@ -274,10 +274,13 @@ def _compact_reasoning(
                 )
             return merged
 
-        # Still starved — update reasoning for next attempt
+        # Still starved — accumulate reasoning for next attempt so later
+        # prompts (especially force-answer) have the full reasoning chain,
+        # not just the latest retry's fragment.
         new_reasoning = comp_response.reasoning_content or ""
         if new_reasoning.strip():
-            reasoning = _truncate_reasoning(new_reasoning)
+            combined = reasoning + "\n\n" + new_reasoning
+            reasoning = _truncate_reasoning(combined)
 
     if workspace_dir:
         log_scaffold_event(
@@ -374,8 +377,21 @@ def continue_on_max_tokens(
             agent_name=agent_name,
         )
         if compacted is not None:
-            return compacted
-        return first_response
+            # If compaction recovered visible text but the response is still
+            # truncated (stop_reason == "max_tokens"), fall through to the
+            # normal text-continuation path below instead of returning a
+            # half-finished answer.
+            if compacted.stop_reason == "max_tokens":
+                comp_visible = strip_think_tags(compacted.text or "")
+                if comp_visible.strip():
+                    first_response = compacted
+                    visible = comp_visible
+                else:
+                    return compacted
+            else:
+                return compacted
+        else:
+            return first_response
 
     max_retries = config.max_tokens_retries
     if max_retries <= 0:

--- a/src/open_dirac/models.yaml
+++ b/src/open_dirac/models.yaml
@@ -419,9 +419,10 @@ zai-org/GLM-5.1:
 #     tok/s at 16-way. --async-scheduling and --mm-encoder-tp-mode data tied
 #     that within noise. K2.5 Eagle3 draft is blocked: spec decoding cannot
 #     use PP>1, while TP=32/PP=1 fails during Kimi vision-tower init.
-#   - 131k max output tokens → TOO LOW for the full one-shot CritPt sweep.
-#     Five hard problems reached max_tokens before emitting answer code. Raising
-#     max_output_tokens to 200k let the final retry finish all 70 submissions.
+#   - 65k max output tokens → TOO LOW for reasoning-heavy agents. ~50% of
+#     researcher calls hit the limit and wasted 15 min on reasoning without
+#     producing output. Raised to 131k with per-agent overrides for lighter
+#     agents (orchestrator, formatter) via agent_max_tokens config.
 #   - OpenDirac agent harness without Kimi tool parser → BROKEN. vLLM rejects
 #     requests with `tool_choice="auto"` unless the server is launched with
 #     --enable-auto-tool-choice and a matching --tool-call-parser. Kimi-K2.6
@@ -443,8 +444,10 @@ moonshotai/Kimi-K2.6:
   input_cost: 0.0
   output_cost: 0.0
   # PP=4 (4 nodes/replica) supports the full 262k context without OOM.
-  # 65k output tokens is plenty for OpenDirac multi-agent turns.
-  max_output_tokens: 65536
+  # 128k output tokens gives reasoning-heavy agents room to finish thinking.
+  # Per-agent overrides in agent_max_tokens cap lighter agents (orchestrator,
+  # formatter) to avoid wasting budget on reasoning loops.
+  max_output_tokens: 131072
   reasoning_format: separate_field
   tool_mode: api
   serve:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -235,7 +235,7 @@ class TestModelRegistryResolution:
         cfg = Config(model="moonshotai/Kimi-K2.6")
         assert cfg.provider == "vllm"
         assert cfg.model_id == "moonshotai/Kimi-K2.6"
-        assert cfg.max_tokens == 65536
+        assert cfg.max_tokens == 131072
         assert cfg.reasoning["reasoning_format"] == "separate_field"
         assert cfg.reasoning["tool_mode"] == "api"
 
@@ -436,3 +436,47 @@ class TestVerifyParser:
         parser = build_verify_parser()
         with pytest.raises(SystemExit):
             parser.parse_args(["ws", "--max-tokens", "8192"])
+
+
+# ---------------------------------------------------------------------------
+# Per-agent max_tokens
+# ---------------------------------------------------------------------------
+
+
+class TestPerAgentMaxTokens:
+    def test_default_has_per_agent_overrides(self):
+        cfg = Config(model="claude-4.6-opus")
+        assert cfg.max_tokens_for_agent("orchestrator") == 16384
+        assert cfg.max_tokens_for_agent("formatter") == 16384
+        assert cfg.max_tokens_for_agent("computer") == 65536
+        assert cfg.max_tokens_for_agent("reviewer") == 65536
+        assert cfg.max_tokens_for_agent("deep_critic") == 65536
+        assert cfg.max_tokens_for_agent("planner") == 65536
+        assert cfg.max_tokens_for_agent("adjudicator") == 65536
+        assert cfg.max_tokens_for_agent("researcher") == cfg.max_tokens
+        assert cfg.max_tokens_for_agent("surveyor") == cfg.max_tokens
+
+    def test_override_returns_agent_value(self):
+        cfg = Config(
+            model="claude-4.6-opus",
+            agent_max_tokens={"formatter": 16384, "orchestrator": 8192},
+        )
+        assert cfg.max_tokens_for_agent("formatter") == 16384
+        assert cfg.max_tokens_for_agent("orchestrator") == 8192
+        assert cfg.max_tokens_for_agent("researcher") == cfg.max_tokens
+
+    def test_empty_override_falls_back(self):
+        cfg = Config(model="claude-4.6-opus", agent_max_tokens={})
+        assert cfg.max_tokens_for_agent("formatter") == cfg.max_tokens
+
+    def test_agent_max_tokens_persisted(self):
+        cfg = Config(
+            model="claude-4.6-opus",
+            agent_max_tokens={"formatter": 16384},
+        )
+        d = cfg.to_dict()
+        assert d["agent_max_tokens"] == {"formatter": 16384}
+
+    def test_max_compaction_retries_default(self):
+        cfg = Config(model="claude-4.6-opus")
+        assert cfg.max_compaction_retries == DEFAULTS["max_compaction_retries"]

--- a/tests/test_max_tokens_retry.py
+++ b/tests/test_max_tokens_retry.py
@@ -678,23 +678,34 @@ def test_compaction_continues_then_succeeds():
 
 
 def test_compaction_force_answer_after_continues_exhausted():
-    """All continue attempts starve → force-answer fires as final attempt."""
+    """All continue attempts starve → force-answer fires as final attempt.
+    The force-answer prompt should contain accumulated reasoning from all
+    prior attempts, not just the latest one."""
     from open_dirac.llm import _compact_reasoning
 
     provider = MagicMock()
     provider.prepare_messages.side_effect = lambda m: m
 
-    always_starve = ProviderResponse(
+    starve_1 = ProviderResponse(
         text="",
         input_tokens=20,
         output_tokens=65536,
         stop_reason="max_tokens",
         reasoning_tokens=65536,
         answer_tokens=0,
-        reasoning_content="More reasoning...",
+        reasoning_content="Reasoning from attempt 1...",
+    )
+    starve_2 = ProviderResponse(
+        text="",
+        input_tokens=20,
+        output_tokens=65536,
+        stop_reason="max_tokens",
+        reasoning_tokens=65536,
+        answer_tokens=0,
+        reasoning_content="Reasoning from attempt 2...",
     )
     # 2 continues starve, force-answer succeeds
-    provider.call.side_effect = [always_starve, always_starve, _ok("Forced answer.")]
+    provider.call.side_effect = [starve_1, starve_2, _ok("Forced answer.")]
 
     starved = _truncated(
         "",
@@ -721,6 +732,10 @@ def test_compaction_force_answer_after_continues_exhausted():
     # Last call should use force-answer prompt
     last_msg = provider.call.call_args_list[-1][1]["messages"][-1]["content"]
     assert "Do NOT continue reasoning" in last_msg
+    # Force-answer should contain accumulated reasoning, not just the latest
+    assert "Initial reasoning" in last_msg
+    assert "Reasoning from attempt 1" in last_msg
+    assert "Reasoning from attempt 2" in last_msg
 
 
 def test_compaction_exhausted_returns_none():
@@ -793,3 +808,46 @@ def test_compaction_integrates_with_continue_on_max_tokens():
     assert result.stop_reason == "end_turn"
     # 1 continue attempt succeeds
     assert provider.call.call_count == 1
+
+
+def test_compaction_truncated_answer_falls_through_to_continuation():
+    """When compaction recovers visible text but is still truncated
+    (stop_reason=max_tokens), continue_on_max_tokens runs the normal
+    text-continuation path on it."""
+    provider = MagicMock()
+    provider.prepare_messages.side_effect = lambda m: m
+
+    # Compaction produces partial answer, still truncated
+    partial = ProviderResponse(
+        text="The Hawking temperature is T = ",
+        input_tokens=20,
+        output_tokens=50,
+        stop_reason="max_tokens",
+    )
+    # Text continuation completes it
+    provider.call.side_effect = [partial, _ok("ℏκ/2π.")]
+
+    starved = _truncated(
+        "",
+        reasoning_content="Deep reasoning about black hole thermodynamics...",
+        reasoning_tokens=65536,
+        answer_tokens=0,
+    )
+    config = _make_config(max_compaction_retries=1, max_tokens_retries=2)
+
+    result = continue_on_max_tokens(
+        provider,
+        starved,
+        config,
+        model="m",
+        max_tokens=100,
+        system="s",
+        messages=[{"role": "user", "content": "q"}],
+    )
+
+    # Should contain both the partial and the continuation
+    assert "The Hawking temperature is T = " in result.text
+    assert "ℏκ/2π." in result.text
+    assert result.stop_reason == "end_turn"
+    # 1 compaction call + 1 text continuation call = 2
+    assert provider.call.call_count == 2

--- a/tests/test_max_tokens_retry.py
+++ b/tests/test_max_tokens_retry.py
@@ -519,3 +519,259 @@ def test_merge_responses_sums_tokens_and_concatenates_text():
     assert merged.output_tokens == first.output_tokens + cont.output_tokens
     # raw_content / tool_calls / stop_reason from the continuation.
     assert merged.stop_reason == cont.stop_reason
+
+
+# ---------------------------------------------------------------------------
+# Reasoning compaction
+# ---------------------------------------------------------------------------
+
+
+def test_compaction_fires_when_reasoning_content_available():
+    """First continue attempt succeeds → 1 provider call."""
+    from open_dirac.llm import _compact_reasoning
+
+    provider = MagicMock()
+    provider.prepare_messages.side_effect = lambda m: m
+    provider.call.return_value = _ok("The answer is 42.")
+
+    starved = _truncated(
+        "",
+        reasoning_content="Long reasoning about the problem...",
+        reasoning_tokens=65536,
+        answer_tokens=0,
+    )
+    config = _make_config(max_compaction_retries=2)
+
+    result = _compact_reasoning(
+        provider,
+        starved,
+        config,
+        model="m",
+        max_tokens=100,
+        system="s",
+        messages=[{"role": "user", "content": "q"}],
+    )
+
+    assert result is not None
+    assert "The answer is 42." in result.text
+    assert result.stop_reason == "end_turn"
+    assert provider.call.call_count == 1
+
+
+def test_compaction_uses_continue_prompt_first():
+    """The first attempt uses the 'continue' prompt, not the force-answer prompt."""
+    from open_dirac.llm import _compact_reasoning
+
+    provider = MagicMock()
+    provider.prepare_messages.side_effect = lambda m: m
+    provider.call.return_value = _ok("Answer.")
+
+    starved = _truncated(
+        "",
+        reasoning_content="Some reasoning...",
+        reasoning_tokens=65536,
+        answer_tokens=0,
+    )
+    config = _make_config(max_compaction_retries=2)
+
+    _compact_reasoning(
+        provider,
+        starved,
+        config,
+        model="m",
+        max_tokens=100,
+        system="s",
+        messages=[{"role": "user", "content": "q"}],
+    )
+
+    sent_messages = provider.call.call_args[1]["messages"]
+    last_user_msg = sent_messages[-1]["content"]
+    assert "Continue from where you left off" in last_user_msg
+    assert "Do NOT continue reasoning" not in last_user_msg
+
+
+def test_compaction_returns_none_without_reasoning():
+    """Compaction is skipped when there is no reasoning_content."""
+    from open_dirac.llm import _compact_reasoning
+
+    provider = MagicMock()
+    starved = _truncated("", reasoning_content="")
+    config = _make_config(max_compaction_retries=2)
+
+    result = _compact_reasoning(
+        provider,
+        starved,
+        config,
+        model="m",
+        max_tokens=100,
+        system="s",
+        messages=[{"role": "user", "content": "q"}],
+    )
+
+    assert result is None
+    provider.call.assert_not_called()
+
+
+def test_compaction_returns_none_when_retries_zero():
+    from open_dirac.llm import _compact_reasoning
+
+    provider = MagicMock()
+    starved = _truncated("", reasoning_content="some reasoning")
+    config = _make_config(max_compaction_retries=0)
+
+    result = _compact_reasoning(
+        provider,
+        starved,
+        config,
+        model="m",
+        max_tokens=100,
+        system="s",
+        messages=[{"role": "user", "content": "q"}],
+    )
+
+    assert result is None
+
+
+def test_compaction_continues_then_succeeds():
+    """First continue starves, second continue succeeds → 2 calls, both 'continue'."""
+    from open_dirac.llm import _compact_reasoning
+
+    provider = MagicMock()
+    provider.prepare_messages.side_effect = lambda m: m
+
+    second_starve = ProviderResponse(
+        text="", input_tokens=20, output_tokens=65536,
+        stop_reason="max_tokens", reasoning_tokens=65536, answer_tokens=0,
+        reasoning_content="Even more detailed reasoning...",
+    )
+    provider.call.side_effect = [second_starve, _ok("Final answer.")]
+
+    starved = _truncated(
+        "", reasoning_content="Initial reasoning...",
+        reasoning_tokens=65536, answer_tokens=0,
+    )
+    config = _make_config(max_compaction_retries=2)
+
+    result = _compact_reasoning(
+        provider,
+        starved,
+        config,
+        model="m",
+        max_tokens=100,
+        system="s",
+        messages=[{"role": "user", "content": "q"}],
+    )
+
+    assert result is not None
+    assert "Final answer." in result.text
+    assert provider.call.call_count == 2
+    # Both calls should have used the continue prompt
+    for call_args in provider.call.call_args_list:
+        last_msg = call_args[1]["messages"][-1]["content"]
+        assert "Continue from where you left off" in last_msg
+
+
+def test_compaction_force_answer_after_continues_exhausted():
+    """All continue attempts starve → force-answer fires as final attempt."""
+    from open_dirac.llm import _compact_reasoning
+
+    provider = MagicMock()
+    provider.prepare_messages.side_effect = lambda m: m
+
+    always_starve = ProviderResponse(
+        text="", input_tokens=20, output_tokens=65536,
+        stop_reason="max_tokens", reasoning_tokens=65536, answer_tokens=0,
+        reasoning_content="More reasoning...",
+    )
+    # 2 continues starve, force-answer succeeds
+    provider.call.side_effect = [always_starve, always_starve, _ok("Forced answer.")]
+
+    starved = _truncated(
+        "", reasoning_content="Initial reasoning...",
+        reasoning_tokens=65536, answer_tokens=0,
+    )
+    config = _make_config(max_compaction_retries=2)
+
+    result = _compact_reasoning(
+        provider,
+        starved,
+        config,
+        model="m",
+        max_tokens=100,
+        system="s",
+        messages=[{"role": "user", "content": "q"}],
+    )
+
+    assert result is not None
+    assert "Forced answer." in result.text
+    # 2 continue + 1 force = 3 calls
+    assert provider.call.call_count == 3
+    # Last call should use force-answer prompt
+    last_msg = provider.call.call_args_list[-1][1]["messages"][-1]["content"]
+    assert "Do NOT continue reasoning" in last_msg
+
+
+def test_compaction_exhausted_returns_none():
+    """All attempts (continues + force) starve → returns None."""
+    from open_dirac.llm import _compact_reasoning
+
+    provider = MagicMock()
+    provider.prepare_messages.side_effect = lambda m: m
+
+    always_starve = ProviderResponse(
+        text="", input_tokens=20, output_tokens=65536,
+        stop_reason="max_tokens", reasoning_tokens=65536, answer_tokens=0,
+        reasoning_content="More reasoning that goes nowhere...",
+    )
+    provider.call.return_value = always_starve
+
+    starved = _truncated(
+        "", reasoning_content="Initial reasoning...",
+        reasoning_tokens=65536, answer_tokens=0,
+    )
+    config = _make_config(max_compaction_retries=2)
+
+    result = _compact_reasoning(
+        provider,
+        starved,
+        config,
+        model="m",
+        max_tokens=100,
+        system="s",
+        messages=[{"role": "user", "content": "q"}],
+    )
+
+    assert result is None
+    # 2 continue + 1 force = 3 total
+    assert provider.call.call_count == 3
+
+
+def test_compaction_integrates_with_continue_on_max_tokens():
+    """End-to-end: continue_on_max_tokens calls compaction when reasoning is
+    starved but reasoning_content is available."""
+    provider = MagicMock()
+    provider.prepare_messages.side_effect = lambda m: m
+    provider.call.return_value = _ok("Recovered answer.")
+
+    starved = _truncated(
+        "",
+        reasoning_content="Deep physics reasoning about gauge invariance...",
+        reasoning_tokens=65536,
+        answer_tokens=0,
+    )
+    config = _make_config(max_compaction_retries=1)
+
+    result = continue_on_max_tokens(
+        provider,
+        starved,
+        config,
+        model="m",
+        max_tokens=100,
+        system="s",
+        messages=[{"role": "user", "content": "q"}],
+    )
+
+    assert "Recovered answer." in result.text
+    assert result.stop_reason == "end_turn"
+    # 1 continue attempt succeeds
+    assert provider.call.call_count == 1

--- a/tests/test_max_tokens_retry.py
+++ b/tests/test_max_tokens_retry.py
@@ -640,15 +640,21 @@ def test_compaction_continues_then_succeeds():
     provider.prepare_messages.side_effect = lambda m: m
 
     second_starve = ProviderResponse(
-        text="", input_tokens=20, output_tokens=65536,
-        stop_reason="max_tokens", reasoning_tokens=65536, answer_tokens=0,
+        text="",
+        input_tokens=20,
+        output_tokens=65536,
+        stop_reason="max_tokens",
+        reasoning_tokens=65536,
+        answer_tokens=0,
         reasoning_content="Even more detailed reasoning...",
     )
     provider.call.side_effect = [second_starve, _ok("Final answer.")]
 
     starved = _truncated(
-        "", reasoning_content="Initial reasoning...",
-        reasoning_tokens=65536, answer_tokens=0,
+        "",
+        reasoning_content="Initial reasoning...",
+        reasoning_tokens=65536,
+        answer_tokens=0,
     )
     config = _make_config(max_compaction_retries=2)
 
@@ -679,16 +685,22 @@ def test_compaction_force_answer_after_continues_exhausted():
     provider.prepare_messages.side_effect = lambda m: m
 
     always_starve = ProviderResponse(
-        text="", input_tokens=20, output_tokens=65536,
-        stop_reason="max_tokens", reasoning_tokens=65536, answer_tokens=0,
+        text="",
+        input_tokens=20,
+        output_tokens=65536,
+        stop_reason="max_tokens",
+        reasoning_tokens=65536,
+        answer_tokens=0,
         reasoning_content="More reasoning...",
     )
     # 2 continues starve, force-answer succeeds
     provider.call.side_effect = [always_starve, always_starve, _ok("Forced answer.")]
 
     starved = _truncated(
-        "", reasoning_content="Initial reasoning...",
-        reasoning_tokens=65536, answer_tokens=0,
+        "",
+        reasoning_content="Initial reasoning...",
+        reasoning_tokens=65536,
+        answer_tokens=0,
     )
     config = _make_config(max_compaction_retries=2)
 
@@ -719,15 +731,21 @@ def test_compaction_exhausted_returns_none():
     provider.prepare_messages.side_effect = lambda m: m
 
     always_starve = ProviderResponse(
-        text="", input_tokens=20, output_tokens=65536,
-        stop_reason="max_tokens", reasoning_tokens=65536, answer_tokens=0,
+        text="",
+        input_tokens=20,
+        output_tokens=65536,
+        stop_reason="max_tokens",
+        reasoning_tokens=65536,
+        answer_tokens=0,
         reasoning_content="More reasoning that goes nowhere...",
     )
     provider.call.return_value = always_starve
 
     starved = _truncated(
-        "", reasoning_content="Initial reasoning...",
-        reasoning_tokens=65536, answer_tokens=0,
+        "",
+        reasoning_content="Initial reasoning...",
+        reasoning_tokens=65536,
+        answer_tokens=0,
     )
     config = _make_config(max_compaction_retries=2)
 


### PR DESCRIPTION
# feat: reasoning compaction and per-agent token budgets

## Problem

Reasoning models like Kimi-K2.6 frequently enter "reasoning starvation" — they spend their entire output token budget on internal reasoning (thinking) without producing any visible answer. Analysis of a 70-problem CritPt evaluation run revealed:

- **305 unrecoverable max_tokens events** across all agents, with the **researcher** responsible for 210 (69%)
- The researcher had a **50% failure rate** — half of all its LLM calls burned the full 65K token budget on reasoning and produced zero output
- Each starved call wasted **~15 minutes of GPU time**
- The **formatter** had a 31% failure rate, despite its job being purely formatting (not reasoning)
- The **orchestrator** (8%) and **computer** (5%) also suffered but were often saved by the existing continuation mechanism

**Per-agent breakdown of reasoning starvation (70-problem CritPt eval, Kimi-K2.6, `max_output_tokens=65536`):**


| Agent          | `max_tokens_unrecoverable` | `reasoning_starved` | Last agent in failed ws |
| -------------- | -------------------------- | ------------------- | ----------------------- |
| **researcher** | **210**                    | **210**             | **12**                  |
| formatter      | 36                         | 36                  | 17                      |
| deep_critic    | 19                         | 19                  | 0                       |
| reviewer       | 14                         | 14                  | 0                       |
| surveyor       | 13                         | 13                  | 0                       |
| planner        | 13                         | 13                  | 1                       |
| orchestrator   | 0                          | 142                 | 0                       |
| computer       | 0                          | 71                  | 0                       |


**Per-agent output token distributions (successful calls only):**


| Agent        | Failure % | P50 output | P95 output | Max output | Suggested max_tokens | Rationale                                         |
| ------------ | --------- | ---------- | ---------- | ---------- | -------------------- | ------------------------------------------------- |
| orchestrator | 8%        | 1,559      | 47,740     | 65,536     | 16,384               | P50 is tiny. Mostly short dispatch decisions.     |
| formatter    | 31%       | 4,231      | 51,246     | 65,536     | 16,384               | Only formatting, not reasoning.                   |
| researcher   | 50%       | 30,245     | 64,630     | 65,536     | 131,072              | At the 65K cliff. Needs room, compaction catches. |
| surveyor     | 12%       | 41,000     | 62,845     | 65,536     | 131,072              | Near the cliff but low volume (110 calls).        |
| computer     | 5%        | 12,543     | 46,266     | 65,536     | 65,536               | Needs room for code output. Keep as-is.           |
| reviewer     | 4%        | 27,891     | 51,598     | 65,536     | 65,536               | Reasonable, rarely fails.                         |
| deep_critic  | 6%        | 31,456     | 55,684     | 65,536     | 65,536               | Reasonable, rarely fails.                         |
| planner      | 4%        | 28,710     | 51,933     | 157,000    | 65,536               | Some outliers from continuation.                  |
| adjudicator  | 0%        | 25,300     | 54,139     | 65,536     | 65,536               | Never fails.                                      |


**Back-of-the-napkin GPU hours wasted:**

Out of 4,707 total LLM calls (473 hours of wall-clock inference time on an 8-replica × 4-node PP=4 setup with 256 H100 GPUs), **518 calls (151.8 hours) were pure waste** — the model spent an average of 17.6 minutes per call generating reasoning tokens and produced zero usable output. That's **32% of all inference time** thrown away.


| Agent        | Starved calls | Hours wasted | Mean duration |
| ------------ | ------------- | ------------ | ------------- |
| researcher   | 210           | 60.3         | 17.2 min      |
| orchestrator | 142           | 40.8         | 17.3 min      |
| computer     | 71            | 20.4         | 17.3 min      |
| formatter    | 36            | 9.5          | 15.8 min      |
| surveyor     | 13            | 7.0          | 32.2 min      |
| deep_critic  | 19            | 5.8          | 18.2 min      |
| reviewer     | 14            | 4.2          | 17.8 min      |
| planner      | 13            | 3.8          | 17.7 min      |


The core issue: all agents shared a single `max_output_tokens = 65536` budget, and there was no recovery mechanism when the model used the entire budget on reasoning. The reasoning content (which often contained valuable partial work) was simply discarded.

Analysis of fail-then-succeed patterns showed that the reasoning is almost certainly on-track — the same problems that fail with reasoning starvation on some iterations succeed on others when the model happens to finish thinking within budget. The answer portion is tiny (~1K tokens) compared to reasoning (30-65K tokens). The model just needs to be given a chance to "conclude" based on its prior reasoning.

## Solution

Three complementary mechanisms, all working at the `llm.py` layer so every agent benefits:

### 1. Two-stage reasoning compaction (`_compact_reasoning`)

When `max_tokens_reasoning_starved` is detected and the response contains `reasoning_content`, a two-stage recovery kicks in:

**Stage 1 — Continue** (up to `max_compaction_retries` attempts, default 2):
Feed the truncated reasoning back as context and let the model keep thinking with a fresh output budget. The prompt is gentle: *"Your reasoning was cut off due to output length limits. Here is your reasoning so far: [...]. Continue from where you left off."* This preserves answer quality because the model can finish its derivation naturally rather than being forced to conclude from incomplete reasoning.

**Stage 2 — Force answer** (1 final attempt after all continues are exhausted):
If the model still can't produce visible output after all continuation attempts, force a conclusion: *"Based on ALL your reasoning so far, now produce your FINAL ANSWER. Do NOT continue reasoning — go straight to the answer."*

This means with the default `max_compaction_retries=2`, the model gets up to 3 chances total (2 continue + 1 force) before the call is marked unrecoverable. The original messages (task/instruction) are preserved in every compaction call.

### 2. Per-agent `max_output_tokens` overrides (`agent_max_tokens`)

New `Config.agent_max_tokens` dict allows setting different token budgets per agent. Agents not listed fall back to the model-level default. This is useful for:

- **Orchestrator** (P50 output: 1,559 tokens): doesn't need 128K — capping at 16K makes it fail fast
- **Formatter** (P50 output: 4,231 tokens): purely formatting, not reasoning — 16K is plenty
- **Researcher** (P95 output: 64,630 tokens): needs the full budget

All LLM call paths (`call_llm`, `call_llm_continuation`, `run_agent_loop`) now use `config.max_tokens_for_agent(agent_name)` instead of `config.max_tokens`.

### 3. Increased default budget for Kimi-K2.6

`max_output_tokens` raised from 65,536 to 131,072. The researcher's successful calls had a P95 output of 64,630 tokens — operating right at the 65K cliff. Doubling the budget gives it room to finish reasoning naturally. Per-agent overrides prevent lighter agents from wasting the larger budget.

### Bonus: Reasoning content now logged

`_write_conversation_log` now includes a `<REASONING>` section when `reasoning_content` is available, preserving the reasoning trace on disk for future debugging. Previously this was discarded.

## Changes


| File                                 | What changed                                                                               |
| ------------------------------------ | ------------------------------------------------------------------------------------------ |
| `src/open_dirac/config.default.yaml` | Added `max_compaction_retries` (default 2) and `agent_max_tokens` with per-agent defaults  |
| `src/open_dirac/core/config.py`      | New fields, `max_tokens_for_agent()` method, persistence/yaml config support               |
| `src/open_dirac/llm.py`              | `_compact_reasoning()` function, per-agent max_tokens in all call paths, reasoning logging |
| `src/open_dirac/models.yaml`         | Kimi-K2.6 `max_output_tokens`: 65536 → 131072, updated experiment notes                    |
| `tests/test_config.py`               | 5 tests for per-agent max_tokens and compaction config                                     |
| `tests/test_max_tokens_retry.py`     | 8 tests for compaction logic (continue, force-answer, retry, exhaustion, integration)      |


## Testing

- All existing tests pass
- 13 new tests covering:
  - Per-agent `max_tokens_for_agent()` with defaults, overrides, fallback, empty dict, persistence
  - `_compact_reasoning`: continue prompt used first, success path, no-reasoning skip, retries-zero skip, double continue then succeed, force-answer after continues exhausted, full exhaustion, end-to-end integration with `continue_on_max_tokens`

## Usage

Per-agent overrides are set in `config.default.yaml`:

```yaml
agent_max_tokens:
  orchestrator: 16384
  formatter: 16384
  computer: 65536
  reviewer: 65536
  deep_critic: 65536
  planner: 65536
  adjudicator: 65536
```

Agents not listed (researcher, surveyor) fall back to the model-level `max_output_tokens` (131K for Kimi-K2.6).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core LLM call/continuation behavior and token budgeting, which can affect agent execution flow and cost/runtime characteristics across all runs. While guarded by config and tests, failures could surface as extra provider calls or unexpected truncation/loop outcomes.
> 
> **Overview**
> Introduces **two-stage reasoning compaction** when a `max_tokens` truncation produces no visible answer: retry with a *continue reasoning* prompt for `max_compaction_retries`, then a final *force answer* attempt, merging recovered output back into the original response.
> 
> Adds **per-agent `max_tokens` overrides** via `agent_max_tokens` and routes all LLM call paths (`call_llm`, `call_llm_continuation`, `run_agent_loop`, forced-final calls) through `Config.max_tokens_for_agent()`.
> 
> Updates defaults to include `max_compaction_retries` and `agent_max_tokens`, raises `moonshotai/Kimi-K2.6` `max_output_tokens` to `131072`, and extends conversation logs to persist `reasoning_content` in a `<REASONING>` section; includes new unit tests covering the compaction stages and per-agent token behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93daaa7684c3f9d35c092e36929109ac80b24d4a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->