### PR TITLE
feat: add GLM 5.1 multi-replica serving with reasoning + xml_text tool support

### DIFF
--- a/serve/full_eval.slurm
+++ b/serve/full_eval.slurm
@@ -162,7 +162,7 @@ trap cleanup EXIT
 
 if [[ ${#SERVE_JOBS[@]} -gt 1 ]]; then
   # Multi-replica: start load balancer and wait for it
-  LB_ARGS=("${SERVE_JOBS[@]}" --port 9000 --health-timeout 1800 --model "$MODEL_KEY")
+  LB_ARGS=("${SERVE_JOBS[@]}" --port 9000 --health-timeout 3600 --model "$MODEL_KEY")
   [[ -n "$NODES_PER_REPLICA" ]] && LB_ARGS+=(--nodes-per-replica "$NODES_PER_REPLICA")
   echo "Starting load balancer for ${#SERVE_JOBS[@]} replicas..."
   uv run --no-sync python serve/load_balancer.py "${LB_ARGS[@]}" &

--- a/serve/serve.slurm
+++ b/serve/serve.slurm
@@ -27,8 +27,9 @@ Examples:
   ./serve/serve.slurm --model Qwen/Qwen3.5-4B --nodes 1 --gpus-per-node 1
   ./serve/serve.slurm --model nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16 --nodes 1 --gpus-per-node 1
   ./serve/serve.slurm --model nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16 --nodes 2 --gpus-per-node 8
-  ./serve/serve.slurm --model zai-org/GLM-5.1 --nodes 3 --gpus-per-node 8
-  # Kimi auto-launches 4 replicas (PP=2 each, 8 nodes total) via multi_serve.sh
+  # GLM auto-launches 8 replicas (PP=3 each, 24 nodes total) via multi_serve.sh
+  ./serve/serve.slurm --model zai-org/GLM-5.1
+  # Kimi auto-launches 4 replicas (PP=4 each, 16 nodes total) via multi_serve.sh
   ./serve/serve.slurm --model moonshotai/Kimi-K2.6
   ./serve/serve.slurm --model Qwen/Qwen3.5-4B --nodes 1 --gpus-per-node 1 --reasoning-parser qwen3
 
@@ -234,6 +235,7 @@ TIME_LIMIT="24:00:00"
 PORT="8000"
 SERVED_MODEL_NAME=""
 MAX_MODEL_LEN="262144"
+MAX_MODEL_LEN_EXPLICIT=""
 TP=""
 PP=""
 DP=""
@@ -287,6 +289,7 @@ while [[ $# -gt 0 ]]; do
     --max-model-len)
       require_value "$1" "${2:-}"
       MAX_MODEL_LEN="$2"
+      MAX_MODEL_LEN_EXPLICIT=1
       shift 2
       ;;
     --tp|--tensor-parallel-size)
@@ -347,6 +350,20 @@ MODEL_SLUG="$(slugify "$MODEL")"
 # Resolve model-specific serve defaults from models.yaml
 _RESOLVE_SCRIPT="${SCRIPT_DIR}/resolve_serve_config.py"
 eval "$(uv run --no-sync python "$_RESOLVE_SCRIPT" "$MODEL")"
+
+# If models.yaml vllm_args includes --max-model-len and the user didn't
+# explicitly pass it on the CLI, adopt the models.yaml value.
+if [[ -z "$MAX_MODEL_LEN_EXPLICIT" ]]; then
+  _skip_next=0
+  for _arg in "${DEFAULT_VLLM_ARGS[@]}"; do
+    if (( _skip_next )); then
+      MAX_MODEL_LEN="$_arg"
+      _skip_next=0
+      break
+    fi
+    [[ "$_arg" == "--max-model-len" ]] && _skip_next=1
+  done
+fi
 
 if [[ -z "${SLURM_JOB_ID:-}" ]]; then
   if [[ -z "$NODES" ]]; then
@@ -446,6 +463,7 @@ if type module >/dev/null 2>&1; then
 fi
 
 export TORCH_COMPILE_DISABLE=1
+export VLLM_ENGINE_READY_TIMEOUT_S="${VLLM_ENGINE_READY_TIMEOUT_S:-1800}"
 
 # DeepGEMM JIT compiles sparse-attention kernels (used by GLM-5.1 and DSv3-class
 # MoE models) at first call. Put cubins in the shared HF cache when available so
@@ -540,7 +558,7 @@ if [[ -z "$SERVED_MODEL_NAME" ]]; then
   SERVED_MODEL_NAME="${DEFAULT_MODEL_ID:-$MODEL}"
 fi
 # Use the real HF repo id for vLLM's `serve` argument; the alias is only
-# meaningful inside physics-intern's models.yaml.
+# meaningful inside open-dirac's models.yaml.
 MODEL_ID="${DEFAULT_MODEL_ID:-$MODEL}"
 if [[ -z "$REASONING_PARSER" ]]; then
   REASONING_PARSER="$DEFAULT_REASONING_PARSER"
@@ -616,10 +634,12 @@ if (( DP > 1 )); then
     --data-parallel-rpc-port "$DP_RPC_PORT"
   )
   # Scale API server count for large DP to avoid head-node bottleneck.
+  # Stored separately: only the head node gets this (--headless is incompatible).
+  HEAD_EXTRA_ARGS=()
   if (( DP >= 8 )); then
-    VLLM_ARGS+=(--api-server-count 4)
+    HEAD_EXTRA_ARGS+=(--api-server-count 4)
   elif (( DP >= 4 )); then
-    VLLM_ARGS+=(--api-server-count 2)
+    HEAD_EXTRA_ARGS+=(--api-server-count 2)
   fi
 else
   VLLM_ARGS+=(--pipeline-parallel-size "$PP")
@@ -659,8 +679,8 @@ if [[ -n "$REASONING_PARSER" && "$REASONING_PARSER" != "none" && "$REASONING_PAR
   fi
 fi
 
-# Filter flags from DEFAULT_VLLM_ARGS that are already set in the base
-# VLLM_ARGS to prevent models.yaml defaults from overriding CLI values.
+# Filter --max-model-len from DEFAULT_VLLM_ARGS (it's already in the base
+# VLLM_ARGS via $MAX_MODEL_LEN) to prevent duplication.
 FILTERED_DEFAULT_ARGS=()
 _skip_next=0
 for _arg in "${DEFAULT_VLLM_ARGS[@]}"; do
@@ -727,7 +747,9 @@ launch_dp_node() {
   local node_idx="$2"
   local start_rank=$(( node_idx * DP_LOCAL ))
   local -a rank_cmd=(uv run --no-sync vllm "${VLLM_ARGS[@]}")
-  if (( node_idx > 0 )); then
+  if (( node_idx == 0 )); then
+    rank_cmd+=("${HEAD_EXTRA_ARGS[@]}")
+  else
     rank_cmd+=(
       --headless
       --data-parallel-start-rank "$start_rank"

--- a/src/physics_intern/models.yaml
+++ b/src/physics_intern/models.yaml
@@ -341,10 +341,16 @@ zai-org/GLM-5.1:
   output_cost: 0.0
   max_output_tokens: 131072
   reasoning_format: separate_field
-  tool_mode: api
+  # GLM's custom model code crashes with --enable-auto-tool-choice due to
+  # CompilerManager.compile() not accepting the is_encoder kwarg.
+  # Use xml_text mode: tools are rendered in the system prompt, model
+  # responds with <tool_call> XML tags parsed by the provider.
+  tool_mode: xml_text
   serve:
-    nodes: 3
+    replicas: 8
+    nodes_per_replica: 3
     gpus_per_node: 8
+    reasoning_parser: glm45
     vllm_args:
       - --max-model-len 163840
       - --trust-remote-code

--- a/src/physics_intern/providers/vllm.py
+++ b/src/physics_intern/providers/vllm.py
@@ -38,12 +38,22 @@ _TOOL_CALL_RE = re.compile(
     r"<tool_call>\s*(.*?)\s*</tool_call>",
     re.DOTALL,
 )
+# Nemotron format: <function=NAME><parameter=KEY>value</parameter></function>
 _FUNCTION_RE = re.compile(
     r"<function=(\w+)>(.*?)</function>",
     re.DOTALL,
 )
 _PARAMETER_RE = re.compile(
     r"<parameter=(\w+)>(.*?)</parameter>",
+    re.DOTALL,
+)
+# GLM format: func_name\n<arg_key>key</arg_key><arg_value>value</arg_value>
+_GLM_FUNC_RE = re.compile(
+    r"^(\S+?)(?:\s|<arg_key>)",
+    re.DOTALL,
+)
+_GLM_ARG_RE = re.compile(
+    r"<arg_key>(.*?)</arg_key>\s*<arg_value>(.*?)</arg_value>",
     re.DOTALL,
 )
 
@@ -149,7 +159,11 @@ class VLLMProvider(LLMProvider):
 
     @staticmethod
     def _parse_xml_tool_calls(text: str) -> list[dict]:
-        """Parse Nemotron XML tool calls from response text.
+        """Parse XML tool calls from response text.
+
+        Supports two formats:
+        - Nemotron: ``<function=NAME><parameter=KEY>value</parameter></function>``
+        - GLM: ``func_name\\n<arg_key>key</arg_key><arg_value>value</arg_value>``
 
         Returns normalised tool calls: ``[{"id": ..., "name": ..., "input": {...}}]``
         or an empty list if none found / parse failure.
@@ -157,26 +171,40 @@ class VLLMProvider(LLMProvider):
         calls: list[dict] = []
         for idx, block_match in enumerate(_TOOL_CALL_RE.finditer(text)):
             block = block_match.group(1)
+
+            # Try Nemotron format first
             func_match = _FUNCTION_RE.search(block)
-            if not func_match:
+            if func_match:
+                func_name = func_match.group(1)
+                body = func_match.group(2)
+                arguments: dict = {}
+                for pm in _PARAMETER_RE.finditer(body):
+                    key = pm.group(1)
+                    raw_value = pm.group(2).strip()
+                    try:
+                        arguments[key] = json.loads(raw_value)
+                    except (json.JSONDecodeError, ValueError):
+                        arguments[key] = raw_value
+                calls.append(
+                    {"id": f"xmlcall_{idx}", "name": func_name, "input": arguments}
+                )
                 continue
-            func_name = func_match.group(1)
-            body = func_match.group(2)
-            arguments: dict = {}
-            for pm in _PARAMETER_RE.finditer(body):
-                key = pm.group(1)
-                raw_value = pm.group(2).strip()
-                try:
-                    arguments[key] = json.loads(raw_value)
-                except (json.JSONDecodeError, ValueError):
-                    arguments[key] = raw_value
-            calls.append(
-                {
-                    "id": f"xmlcall_{idx}",
-                    "name": func_name,
-                    "input": arguments,
-                }
-            )
+
+            # Try GLM format: func_name followed by <arg_key>/<arg_value> pairs
+            glm_match = _GLM_FUNC_RE.match(block) if "<arg_key>" in block else None
+            if glm_match:
+                func_name = glm_match.group(1).strip()
+                arguments = {}
+                for am in _GLM_ARG_RE.finditer(block):
+                    key = am.group(1).strip()
+                    raw_value = am.group(2).strip()
+                    try:
+                        arguments[key] = json.loads(raw_value)
+                    except (json.JSONDecodeError, ValueError):
+                        arguments[key] = raw_value
+                calls.append(
+                    {"id": f"xmlcall_{idx}", "name": func_name, "input": arguments}
+                )
         return calls
 
     # Back-compat alias — prefer importing ``strip_tool_messages`` from

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -229,7 +229,7 @@ class TestModelRegistryResolution:
         assert cfg.model_id == "zai-org/GLM-5.1"
         assert cfg.max_tokens == 131072
         assert cfg.reasoning["reasoning_format"] == "separate_field"
-        assert cfg.reasoning["tool_mode"] == "api"
+        assert cfg.reasoning["tool_mode"] == "xml_text"
 
     def test_kimi_k2_6_local_vllm_key_resolves(self):
         cfg = Config(model="moonshotai/Kimi-K2.6")
@@ -256,12 +256,13 @@ class TestServeConfig:
 
     def test_glm_5_1_serve_block(self, registry):
         serve = registry["zai-org/GLM-5.1"]["serve"]
-        assert serve["nodes"] == 3
+        assert serve["replicas"] == 8
+        assert serve["nodes_per_replica"] == 3
         assert serve["gpus_per_node"] == 8
+        assert serve["reasoning_parser"] == "glm45"
         args = " ".join(serve["vllm_args"])
-        # DeepGEMM JIT cache/toolkit setup in serve.slurm makes CUDA graphs usable.
         assert "--enforce-eager" not in args
-        assert "--safetensors-load-strategy prefetch" in args  # 17x load speedup
+        assert "--safetensors-load-strategy prefetch" in args
         assert "--trust-remote-code" in args
 
     def test_kimi_k2_6_serve_block(self, registry):
@@ -324,9 +325,10 @@ class TestResolveServeConfig:
     def test_emits_all_required_shell_vars_for_glm(self):
         out = _run_resolver("zai-org/GLM-5.1")
         assert out["DEFAULT_MODEL_ID"] == "zai-org/GLM-5.1"
-        assert out["DEFAULT_REPLICAS"] == "1"
+        assert out["DEFAULT_REPLICAS"] == "8"
         assert out["DEFAULT_NODES"] == "3"
         assert out["DEFAULT_GPUS_PER_NODE"] == "8"
+        assert out["DEFAULT_REASONING_PARSER"] == "glm45"
         assert "--enforce-eager" not in out["DEFAULT_VLLM_ARGS"]
         assert "--safetensors-load-strategy" in out["DEFAULT_VLLM_ARGS"]
 


### PR DESCRIPTION
## Summary

- Configure **GLM 5.1** with 8 replicas (3 PP nodes each), `reasoning_parser: glm45`, and `tool_mode: xml_text` — bypasses the broken `--enable-auto-tool-choice` codepath where GLM's custom `CompilerManager.compile()` rejects the `is_encoder` kwarg
- Fix `serve.slurm` **max-model-len precedence** bug: the script's hardcoded default (262144) was always used instead of the value from `models.yaml`, causing GLM (which needs 163840) to fail validation
- Add **LD_LIBRARY_PATH propagation** for venv nvidia wheel libs to compute nodes — fixes missing `libcudnn.so.9` / `libnvshmem_host.so.3` / `libnvJitLink` at runtime
- Fix DP `--api-server-count` being passed to **headless workers** (incompatible flag); restrict to head node only via `HEAD_EXTRA_ARGS`
- Add **GLM-format XML tool-call parsing** (`<arg_key>`/`<arg_value>` tags) alongside existing Nemotron format in the vLLM provider
- Increase load balancer **health timeout** from 1800s to 3600s for large MoE models that take 40+ minutes to load

## Test plan

- [x] GLM 5.1 eval running successfully with 8 replicas on the cluster (all backends healthy, 500+ requests processed)
- [x] Existing tests pass (`pytest tests/`)
- [ ] Kimi-K2.6 serving still works (no regressions from serve.slurm changes)


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Slurm serving/eval orchestration and runtime environment (`LD_LIBRARY_PATH`, DP/headless flags), which can affect cluster job stability and serving behavior across models.
> 
> **Overview**
> Enables **GLM-5.1** to run as an 8-replica vLLM deployment (3 nodes per replica) with `reasoning_parser: glm45` and `tool_mode: xml_text`, and extends the vLLM provider’s `xml_text` parsing to also recognize GLM’s `<arg_key>/<arg_value>` tool-call format.
> 
> Fixes `serve.slurm` precedence so `--max-model-len` from `models.yaml` is honored unless explicitly set on the CLI, and adjusts DP launching so `--api-server-count` is applied only on the head node (not `--headless` workers).
> 
> Hardens cluster runtime behavior by prioritizing CUDA wheel libraries from the repo venv in `LD_LIBRARY_PATH` (and propagating it to `srun` ranks), and increases the multi-replica eval load balancer health timeout from 30 to 60 minutes for slow-loading models.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e4d495396d7ee31f03b4534f91e7c632c3f40ca. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->