### PR TITLE
Fix formatter empty answer resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ uv sync --extra local
 ./serve/serve.slurm --model deepseek-ai/DeepSeek-V4-Pro
 
 # Run full CritPt evaluation against existing serve jobs from the CPU partition.
+# Resume automatically reuses scoreable `ANSWER.md` files and removes empty
+# formatter artifacts before granting an unfinished workspace more budget.
 ./serve/full_eval.slurm --model deepseek-ai/DeepSeek-V4-Pro --serve-job <JOB_ID>
 
 # Run a research problem (requires model API key in .env or env var)

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ uv sync --extra local
 ./serve/serve.slurm --model deepseek-ai/DeepSeek-V4-Pro
 
 # Run full CritPt evaluation against existing serve jobs from the CPU partition.
-# Resume automatically reuses scoreable `ANSWER.md` files and removes empty
-# formatter artifacts before granting an unfinished workspace more budget.
+# Resume automatically reuses scoreable `ANSWER.md` files and removes empty or
+# formatter-rejection artifacts before granting an unfinished workspace more budget.
 ./serve/full_eval.slurm --model deepseek-ai/DeepSeek-V4-Pro --serve-job <JOB_ID>
 
 # Run a research problem (requires model API key in .env or env var)

--- a/scripts/run_critpt_physics_intern.py
+++ b/scripts/run_critpt_physics_intern.py
@@ -201,6 +201,70 @@ class ResumeAction:
     action: str  # "skip", "extract", "resume", "fresh"
     workspace: Path | None = None
     answer_code: str | None = None
+    cleanup_answer_before_resume: bool = False
+    cleanup_answer_reason: str = ""
+
+
+def _commit_answer_cleanup_before_resume(workspace: Path, reason: str) -> None:
+    """Remove an invalid final answer and commit that cleanup before resume.
+
+    ``physics_intern.main --resume`` refuses any workspace with ``ANSWER.md``
+    because that file is the canonical completion signal. Empty or explicit
+    formatter-rejection answers are not valid submissions, so the batch runner
+    removes them and records the cleanup in the challenge workspace git history
+    before granting more budget.
+    """
+    answer_path = workspace / "ANSWER.md"
+    if not answer_path.exists():
+        return
+
+    answer_text = answer_path.read_text()
+    if answer_text.strip() and not answer_text.lstrip().startswith(
+        "FORMATTER_REJECTION:"
+    ):
+        return
+
+    answer_path.unlink()
+    add_proc = subprocess.run(
+        ["git", "add", "-A", "ANSWER.md"],
+        cwd=str(workspace),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if add_proc.returncode != 0:
+        raise RuntimeError(
+            f"Failed to stage ANSWER.md cleanup in {workspace}: "
+            f"{add_proc.stderr.strip()}"
+        )
+
+    status_proc = subprocess.run(
+        ["git", "status", "--porcelain", "--", "ANSWER.md"],
+        cwd=str(workspace),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if status_proc.returncode != 0:
+        raise RuntimeError(
+            f"Failed to inspect ANSWER.md cleanup in {workspace}: "
+            f"{status_proc.stderr.strip()}"
+        )
+    if not status_proc.stdout.strip():
+        return
+
+    commit_proc = subprocess.run(
+        ["git", "commit", "-m", f"Remove invalid ANSWER.md before resume: {reason}"],
+        cwd=str(workspace),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if commit_proc.returncode != 0:
+        raise RuntimeError(
+            f"Failed to commit ANSWER.md cleanup in {workspace}: "
+            f"{commit_proc.stderr.strip()}"
+        )
 
 
 def plan_actions(
@@ -226,6 +290,8 @@ def plan_actions(
         )
         if ws:
             answer_path = ws / "ANSWER.md"
+            cleanup_answer_before_resume = False
+            cleanup_answer_reason = ""
             if answer_path.exists():
                 code = answer_path.read_text().strip()
                 if code and not code.startswith("FORMATTER_REJECTION"):
@@ -238,6 +304,12 @@ def plan_actions(
                         )
                     )
                     continue
+                cleanup_answer_before_resume = True
+                cleanup_answer_reason = (
+                    "formatter rejection"
+                    if code.startswith("FORMATTER_REJECTION")
+                    else "empty answer"
+                )
             # Workspace exists but no valid answer — try to resume
             graph_path = ws / "RESEARCH_GRAPH.json"
             if graph_path.exists():
@@ -246,6 +318,8 @@ def plan_actions(
                         problem=p,
                         action="resume",
                         workspace=ws,
+                        cleanup_answer_before_resume=cleanup_answer_before_resume,
+                        cleanup_answer_reason=cleanup_answer_reason,
                     )
                 )
                 continue
@@ -411,6 +485,11 @@ async def run_one_problem(
                 stderr=asyncio.subprocess.DEVNULL,
             )
             await p.wait()
+            if action.cleanup_answer_before_resume:
+                _commit_answer_cleanup_before_resume(
+                    ws,
+                    action.cleanup_answer_reason,
+                )
             cmd = [
                 "uv",
                 "run",

--- a/scripts/run_critpt_physics_intern.py
+++ b/scripts/run_critpt_physics_intern.py
@@ -54,6 +54,7 @@ from physics_intern.core.config import load_config_yaml  # noqa: E402
 
 DEFAULT_WORKSPACE_BASE = PROJECT_ROOT / "workspaces"
 DEFAULT_RESULTS_BASE = PROJECT_ROOT / "results" / "critpt"
+FORMATTER_REJECTION_PREFIX = "FORMATTER_REJECTION"
 
 
 # ---------------------------------------------------------------------------
@@ -205,6 +206,11 @@ class ResumeAction:
     cleanup_answer_reason: str = ""
 
 
+def _is_formatter_rejection_answer(answer_text: str) -> bool:
+    """Return whether ``ANSWER.md`` contains a formatter rejection marker."""
+    return answer_text.strip().startswith(FORMATTER_REJECTION_PREFIX)
+
+
 def _commit_answer_cleanup_before_resume(workspace: Path, reason: str) -> None:
     """Remove an invalid final answer and commit that cleanup before resume.
 
@@ -219,9 +225,7 @@ def _commit_answer_cleanup_before_resume(workspace: Path, reason: str) -> None:
         return
 
     answer_text = answer_path.read_text()
-    if answer_text.strip() and not answer_text.lstrip().startswith(
-        "FORMATTER_REJECTION:"
-    ):
+    if answer_text.strip() and not _is_formatter_rejection_answer(answer_text):
         return
 
     answer_path.unlink()
@@ -294,7 +298,7 @@ def plan_actions(
             cleanup_answer_reason = ""
             if answer_path.exists():
                 code = answer_path.read_text().strip()
-                if code and not code.startswith("FORMATTER_REJECTION"):
+                if code and not _is_formatter_rejection_answer(code):
                     actions.append(
                         ResumeAction(
                             problem=p,
@@ -307,7 +311,7 @@ def plan_actions(
                 cleanup_answer_before_resume = True
                 cleanup_answer_reason = (
                     "formatter rejection"
-                    if code.startswith("FORMATTER_REJECTION")
+                    if _is_formatter_rejection_answer(code)
                     else "empty answer"
                 )
             # Workspace exists but no valid answer — try to resume

--- a/src/physics_intern/agents/formatter/agent.py
+++ b/src/physics_intern/agents/formatter/agent.py
@@ -80,6 +80,16 @@ class FormatterAgent(BaseAgent):
         self.rejection_reason = None
         text = response.text or ""
 
+        if response.stop_reason == "max_tokens":
+            self.rejection_reason = (
+                "formatter hit max_tokens before producing a complete answer"
+            )
+            return
+
+        if not text.strip():
+            self.rejection_reason = "formatter produced an empty answer"
+            return
+
         if text.lstrip().startswith(_REJECTION_PREFIX):
             self.rejection_reason = (
                 text.lstrip().split("\n", 1)[0].removeprefix(_REJECTION_PREFIX).strip()

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -297,12 +297,12 @@ class TestProcessResponseRejection:
             config, workspace, metrics, answer_template=answer_template
         )
 
-    def _make_response(self, text):
+    def _make_response(self, text, stop_reason="end_turn"):
         return LLMResponse(
             text=text,
             input_tokens=100,
             output_tokens=50,
-            stop_reason="end_turn",
+            stop_reason=stop_reason,
             duration=1.0,
         )
 
@@ -342,6 +342,26 @@ def answer(x, y):
         agent.process_response(resp, self._make_task(), iteration=1)
         assert agent.rejection_reason is None
         agent.workspace.write_file.assert_called_once()
+
+    def test_empty_output_sets_reason_without_writing_answer(self):
+        agent = self._make_agent(answer_template=SYMPY_TEMPLATE)
+        resp = self._make_response("   \n")
+        agent.process_response(resp, self._make_task(), iteration=1)
+        assert agent.rejection_reason == "formatter produced an empty answer"
+        agent.workspace.write_file.assert_not_called()
+
+    def test_max_tokens_output_sets_reason_without_writing_answer(self):
+        agent = self._make_agent(answer_template=SYMPY_TEMPLATE)
+        resp = self._make_response(
+            "partial answer that may be truncated",
+            stop_reason="max_tokens",
+        )
+        agent.process_response(resp, self._make_task(), iteration=1)
+        assert (
+            agent.rejection_reason
+            == "formatter hit max_tokens before producing a complete answer"
+        )
+        agent.workspace.write_file.assert_not_called()
 
     def test_no_template_always_passes(self):
         agent = self._make_agent(answer_template="")

--- a/tests/test_run_critpt_common.py
+++ b/tests/test_run_critpt_common.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -13,11 +14,16 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
 
 from run_critpt_common import (  # noqa: E402
+    Problem,
     RunResult,
     write_batch_metadata,
     write_initial_batch_metadata,
     load_resume_config,
     find_completed_submissions,
+)
+from run_critpt_physics_intern import (  # noqa: E402
+    _commit_answer_cleanup_before_resume,
+    plan_actions,
 )
 
 
@@ -56,6 +62,80 @@ def _r(
         returncode=0 if success else 1,
         workspace_dir=workspace,
     )
+
+
+def _problem(n: int) -> Problem:
+    return Problem(
+        n=n,
+        problem_id=f"Challenge_{n}_main",
+        yaml_path=Path(f"Challenge_{n}_main.yaml"),
+    )
+
+
+def test_plan_actions_marks_empty_answer_for_resume_cleanup(tmp_path):
+    """An empty ANSWER.md is not scoreable and must not block resume."""
+    output_dir = tmp_path / "results"
+    output_dir.mkdir()
+    workspace_base = tmp_path / "workspaces"
+    safe_model = "deepseek-ai-DeepSeek-V4-Pro"
+    workspace = workspace_base / f"20260508_100000_Challenge_25_main_{safe_model}"
+    workspace.mkdir(parents=True)
+    (workspace / "ANSWER.md").write_text("\n")
+    (workspace / "RESEARCH_GRAPH.json").write_text('{"status": "completed"}')
+
+    actions = plan_actions(
+        problems=[_problem(25)],
+        output_dir=output_dir,
+        workspace_base=workspace_base,
+        model_key="deepseek-ai/DeepSeek-V4-Pro",
+        force=False,
+    )
+
+    assert len(actions) == 1
+    action = actions[0]
+    assert action.action == "resume"
+    assert action.workspace == workspace
+    assert action.cleanup_answer_before_resume is True
+    assert action.cleanup_answer_reason == "empty answer"
+
+
+def test_commit_answer_cleanup_before_resume_removes_committed_empty_answer(tmp_path):
+    """The cleanup leaves the workspace clean so physics_intern.main can resume."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    subprocess.run(["git", "init"], cwd=workspace, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=workspace,
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=workspace,
+        capture_output=True,
+        check=True,
+    )
+    (workspace / "ANSWER.md").write_text("\n")
+    subprocess.run(["git", "add", "-A"], cwd=workspace, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Empty answer"],
+        cwd=workspace,
+        capture_output=True,
+        check=True,
+    )
+
+    _commit_answer_cleanup_before_resume(workspace, "empty answer")
+
+    assert not (workspace / "ANSWER.md").exists()
+    status = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=workspace,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert status.stdout == ""
 
 
 T0 = datetime(2026, 4, 19, 10, 0, 0, tzinfo=timezone.utc)

--- a/tests/test_run_critpt_common.py
+++ b/tests/test_run_critpt_common.py
@@ -72,6 +72,23 @@ def _problem(n: int) -> Problem:
     )
 
 
+def _init_git_repo(workspace: Path) -> None:
+    """Initialise a test git repository that can create cleanup commits."""
+    subprocess.run(["git", "init"], cwd=workspace, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=workspace,
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=workspace,
+        capture_output=True,
+        check=True,
+    )
+
+
 def test_plan_actions_marks_empty_answer_for_resume_cleanup(tmp_path):
     """An empty ANSWER.md is not scoreable and must not block resume."""
     output_dir = tmp_path / "results"
@@ -99,23 +116,38 @@ def test_plan_actions_marks_empty_answer_for_resume_cleanup(tmp_path):
     assert action.cleanup_answer_reason == "empty answer"
 
 
+def test_plan_actions_marks_colonless_formatter_rejection_for_cleanup(tmp_path):
+    """Formatter rejection artifacts must not be treated as scoreable answers."""
+    output_dir = tmp_path / "results"
+    output_dir.mkdir()
+    workspace_base = tmp_path / "workspaces"
+    safe_model = "deepseek-ai-DeepSeek-V4-Pro"
+    workspace = workspace_base / f"20260508_100000_Challenge_25_main_{safe_model}"
+    workspace.mkdir(parents=True)
+    (workspace / "ANSWER.md").write_text("FORMATTER_REJECTION missing final ER\n")
+    (workspace / "RESEARCH_GRAPH.json").write_text('{"status": "completed"}')
+
+    actions = plan_actions(
+        problems=[_problem(25)],
+        output_dir=output_dir,
+        workspace_base=workspace_base,
+        model_key="deepseek-ai/DeepSeek-V4-Pro",
+        force=False,
+    )
+
+    assert len(actions) == 1
+    action = actions[0]
+    assert action.action == "resume"
+    assert action.workspace == workspace
+    assert action.cleanup_answer_before_resume is True
+    assert action.cleanup_answer_reason == "formatter rejection"
+
+
 def test_commit_answer_cleanup_before_resume_removes_committed_empty_answer(tmp_path):
     """The cleanup leaves the workspace clean so physics_intern.main can resume."""
     workspace = tmp_path / "workspace"
     workspace.mkdir()
-    subprocess.run(["git", "init"], cwd=workspace, capture_output=True, check=True)
-    subprocess.run(
-        ["git", "config", "user.email", "test@test.com"],
-        cwd=workspace,
-        capture_output=True,
-        check=True,
-    )
-    subprocess.run(
-        ["git", "config", "user.name", "Test"],
-        cwd=workspace,
-        capture_output=True,
-        check=True,
-    )
+    _init_git_repo(workspace)
     (workspace / "ANSWER.md").write_text("\n")
     subprocess.run(["git", "add", "-A"], cwd=workspace, capture_output=True, check=True)
     subprocess.run(
@@ -126,6 +158,33 @@ def test_commit_answer_cleanup_before_resume_removes_committed_empty_answer(tmp_
     )
 
     _commit_answer_cleanup_before_resume(workspace, "empty answer")
+
+    assert not (workspace / "ANSWER.md").exists()
+    status = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=workspace,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert status.stdout == ""
+
+
+def test_commit_answer_cleanup_before_resume_removes_formatter_rejection(tmp_path):
+    """The cleanup guard matches the resume planner's rejection detection."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _init_git_repo(workspace)
+    (workspace / "ANSWER.md").write_text("FORMATTER_REJECTION missing final ER\n")
+    subprocess.run(["git", "add", "-A"], cwd=workspace, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Formatter rejection answer"],
+        cwd=workspace,
+        capture_output=True,
+        check=True,
+    )
+
+    _commit_answer_cleanup_before_resume(workspace, "formatter rejection")
 
     assert not (workspace / "ANSWER.md").exists()
     status = subprocess.run(


### PR DESCRIPTION
## Summary
- Prevent formatter responses that are empty or still stopped by `max_tokens` from writing `ANSWER.md`.
- Teach the CritPt batch resume flow to clean invalid empty formatter artifacts from challenge workspaces before resuming.
- Add focused tests for formatter finalization and committed empty-answer cleanup.

## Test plan
- `uv run --no-sync python -m pytest tests/test_formatter.py tests/test_run_critpt_common.py`
- `uv run --no-sync ruff check src/physics_intern/agents/formatter/agent.py scripts/run_critpt_physics_intern.py tests/test_formatter.py tests/test_run_critpt_common.py README.md`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes resume behavior for CritPt batch runs by deleting/committing invalid `ANSWER.md` artifacts and tightening formatter output validation; could affect how incomplete runs are resumed and when answers are considered final.
> 
> **Overview**
> Ensures the formatter no longer writes `ANSWER.md` when the LLM output is empty or truncated due to `max_tokens`, treating these as explicit rejections with a recorded `rejection_reason`.
> 
> Updates the CritPt batch resume flow to detect empty or formatter-rejection `ANSWER.md` files in existing workspaces and automatically remove + git-commit that cleanup before invoking `physics_intern.main --resume`, so unfinished runs can continue without being falsely marked complete. Adds README guidance and targeted tests covering the new formatter checks and resume cleanup behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36dc70398519ca42cf9fad08672b3b3776715ae9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->