### PR TITLE
Add elastic backend discovery

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -387,6 +387,40 @@ capacity. If a started replacement still fails to produce a healthy endpoint
 within the timeout, the load balancer cancels that job before submitting another
 replacement so timed-out jobs do not later become orphaned replicas.
 
+The load balancer also supports elastic serving. It scans Slurm every 10 minutes
+by default for running `vllm-serve-<model>` jobs, reads
+`serve/logs/vllm/<job_id>/endpoint.env`, health-checks the endpoint, and adds
+healthy backends without restarting the eval job. This lets you launch extra
+replicas when the cluster is empty and have the running evaluation pick them up
+automatically. If no `--serve-job` is passed to `serve/full_eval.slurm`, the eval
+starts in discovery-only mode and waits for the first matching healthy backend.
+
+To free capacity, do not call `scancel` directly unless you are willing to kill
+in-flight requests. Use the drain helper so the backend receives no new requests
+and is cancelled only after its active request count reaches zero:
+
+```bash
+# Auto-detect the single running critpt-physicsintern eval job.
+./serve/drain_backends.py <BACKEND_JOB_ID> [<BACKEND_JOB_ID> ...] --status
+
+# Or target the eval job explicitly if several eval jobs are running.
+./serve/drain_backends.py \
+  --eval-job <EVAL_JOB_ID> \
+  <BACKEND_JOB_ID_1> <BACKEND_JOB_ID_2> \
+  --status
+```
+
+The helper calls the eval job's local load balancer endpoint
+`/cancel_when_drained/<job_id>` through `srun --overlap`. The backend is marked
+`draining`, disappears from new request scheduling, and is removed from the pool
+after the load balancer cancels the Slurm job. You can inspect the current pool
+with:
+
+```bash
+srun --jobid=<EVAL_JOB_ID> --overlap --ntasks=1 --nodes=1 \
+  curl http://localhost:9000/status
+```
+
 The default DeepSeek config is tuned for high-concurrency CritPt-style traffic.
 To launch a single replica for debugging, override the replica count by calling
 `serve/multi_serve.sh` directly with `--replicas 1`, or call `serve.slurm` from

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ uv sync --extra local
 # Run full CritPt evaluation against existing serve jobs from the CPU partition.
 # Resume automatically reuses scoreable `ANSWER.md` files and removes empty or
 # formatter-rejection artifacts before granting an unfinished workspace more budget.
+# If no --serve-job is provided, the load balancer discovers matching running
+# vLLM serve jobs from Slurm every 10 minutes and adds healthy backends.
 ./serve/full_eval.slurm --model deepseek-ai/DeepSeek-V4-Pro --serve-job <JOB_ID>
 
 # Run a research problem (requires model API key in .env or env var)

--- a/serve/drain_backends.py
+++ b/serve/drain_backends.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Gracefully drain and cancel vLLM backends through a running load balancer."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from typing import Any
+
+
+def _run_command(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    """Run a command and return text output."""
+    return subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+
+def discover_eval_job() -> str:
+    """Return the sole running PhysicsIntern CritPt eval job for this user."""
+    user = os.environ["USER"]
+    proc = _run_command(
+        [
+            "squeue",
+            "-u",
+            user,
+            "--noheader",
+            "--format=%i|%j|%T",
+        ]
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"squeue failed: {proc.stderr.strip()}")
+
+    matches: list[str] = []
+    for line in proc.stdout.splitlines():
+        parts = line.strip().split("|", 2)
+        if len(parts) != 3:
+            continue
+        job_id, name, state = parts
+        if name.startswith("critpt-physicsintern-") and state == "RUNNING":
+            matches.append(job_id)
+
+    if not matches:
+        raise RuntimeError("No running critpt-physicsintern eval job found.")
+    if len(matches) > 1:
+        joined = ", ".join(matches)
+        raise RuntimeError(
+            f"Multiple running eval jobs found ({joined}); pass --eval-job explicitly."
+        )
+    return matches[0]
+
+
+def request_from_eval_job(eval_job: str, path: str, method: str = "GET") -> dict[str, Any]:
+    """Call the load balancer from inside the eval job allocation."""
+    code = f"""\
+import json
+import urllib.request
+
+req = urllib.request.Request("http://localhost:9000{path}", method="{method}")
+with urllib.request.urlopen(req, timeout=30) as resp:
+    print(resp.read().decode())
+"""
+    proc = _run_command(
+        [
+            "srun",
+            f"--jobid={eval_job}",
+            "--overlap",
+            "--ntasks=1",
+            "--nodes=1",
+            "python",
+            "-c",
+            code,
+        ]
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.strip() or proc.stdout.strip())
+    return json.loads(proc.stdout)
+
+
+def main() -> int:
+    """Drain and cancel one or more backend Slurm jobs."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Gracefully drain vLLM backends via the active load balancer, then "
+            "cancel each backend job once its in-flight requests finish."
+        )
+    )
+    parser.add_argument(
+        "backend_job_ids",
+        nargs="+",
+        help="Slurm job IDs of vLLM serve backends to drain and cancel.",
+    )
+    parser.add_argument(
+        "--eval-job",
+        default=None,
+        help="Slurm job ID of the eval job hosting the load balancer.",
+    )
+    parser.add_argument(
+        "--status",
+        action="store_true",
+        help="Print load-balancer status after submitting drain requests.",
+    )
+    args = parser.parse_args()
+
+    eval_job = args.eval_job or discover_eval_job()
+    print(f"Using eval job {eval_job} for load-balancer access.", file=sys.stderr)
+
+    for backend_job_id in args.backend_job_ids:
+        response = request_from_eval_job(
+            eval_job,
+            f"/cancel_when_drained/{backend_job_id}",
+            method="POST",
+        )
+        print(json.dumps(response, indent=2))
+
+    if args.status:
+        status = request_from_eval_job(eval_job, "/status")
+        print(json.dumps(status, indent=2))
+
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (RuntimeError, urllib.error.URLError, json.JSONDecodeError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/serve/drain_backends.py
+++ b/serve/drain_backends.py
@@ -52,7 +52,9 @@ def discover_eval_job() -> str:
     return matches[0]
 
 
-def request_from_eval_job(eval_job: str, path: str, method: str = "GET") -> dict[str, Any]:
+def request_from_eval_job(
+    eval_job: str, path: str, method: str = "GET"
+) -> dict[str, Any]:
     """Call the load balancer from inside the eval job allocation."""
     code = f"""\
 import json

--- a/serve/full_eval.slurm
+++ b/serve/full_eval.slurm
@@ -7,6 +7,9 @@
 # Usage (multi-replica with auto load-balancer):
 #   ./serve/full_eval.slurm --model MODEL_KEY --serve-job J1 --serve-job J2 --serve-job J3
 #
+# Usage (auto-discover already-running matching serve jobs):
+#   ./serve/full_eval.slurm --model MODEL_KEY
+#
 # Usage (physics-intern multi-agent runner with config override):
 #   ./serve/full_eval.slurm --model MODEL_KEY --serve-job J1 --serve-job J2 \
 #     --runner physicsintern --config config.cluster.yaml
@@ -44,6 +47,7 @@ WORKSPACE_BASE=""
 NODES_PER_REPLICA=""
 KEEP_SERVES=""
 PARTITION="hopper-cpu"
+DISCOVER_INTERVAL="600"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -59,17 +63,18 @@ while [[ $# -gt 0 ]]; do
     --nodes-per-replica) NODES_PER_REPLICA="$2"; shift 2 ;;
     --keep-serves) KEEP_SERVES="1"; shift ;;
     --partition) PARTITION="$2"; shift 2 ;;
+    --discover-interval) DISCOVER_INTERVAL="$2"; shift 2 ;;
     *) echo "Unknown argument: $1" >&2; exit 1 ;;
   esac
 done
 
-if [[ -z "$MODEL_KEY" || ${#SERVE_JOBS[@]} -eq 0 ]]; then
+if [[ -z "$MODEL_KEY" ]]; then
   cat >&2 <<'USAGE'
-Usage: full_eval.slurm --model MODEL_KEY --serve-job JOB_ID [--serve-job JOB_ID2 ...]
+Usage: full_eval.slurm --model MODEL_KEY [--serve-job JOB_ID [--serve-job JOB_ID2 ...]]
        [--concurrency N] [--time HH:MM:SS] [--resume DIR]
        [--runner oneshot|physicsintern] [--config CONFIG.yaml]
        [--fresh] [--workspace-base DIR] [--nodes-per-replica N]
-       [--partition PARTITION]
+       [--partition PARTITION] [--discover-interval SECONDS]
 USAGE
   exit 1
 fi
@@ -93,7 +98,11 @@ if [[ -z "${SLURM_JOB_ID:-}" ]]; then
     [[ -f "$ENDPOINT_ENV" ]] || { echo "endpoint.env not found: $ENDPOINT_ENV" >&2; exit 1; }
   fi
 
-  echo "Serve jobs: ${SERVE_JOBS[*]}"
+  if [[ ${#SERVE_JOBS[@]} -eq 0 ]]; then
+    echo "Serve jobs: auto-discover"
+  else
+    echo "Serve jobs: ${SERVE_JOBS[*]}"
+  fi
   echo "Runner:     ${RUNNER}"
   echo "Partition:  ${PARTITION}"
   [[ -n "$CONFIG_FILE" ]] && echo "Config:     ${CONFIG_FILE}"
@@ -138,7 +147,8 @@ if [[ -z "${SLURM_JOB_ID:-}" ]]; then
                    "${WS_ARG[@]}" \
                    "${NPR_ARG[@]}" \
                    "${KS_ARG[@]}" \
-                   --partition "$PARTITION"
+                   --partition "$PARTITION" \
+                   --discover-interval "$DISCOVER_INTERVAL"
 fi
 
 # ── Inside Slurm ─────────────────────────────────────────────────────────────
@@ -167,11 +177,15 @@ cleanup() {
 }
 trap cleanup EXIT
 
-if [[ ${#SERVE_JOBS[@]} -gt 1 ]]; then
+if [[ ${#SERVE_JOBS[@]} -ne 1 ]]; then
   # Multi-replica: start load balancer and wait for it
-  LB_ARGS=("${SERVE_JOBS[@]}" --port 9000 --health-timeout 3600 --model "$MODEL_KEY")
+  LB_ARGS=("${SERVE_JOBS[@]}" --port 9000 --health-timeout 3600 --model "$MODEL_KEY" --discover-interval "$DISCOVER_INTERVAL")
   [[ -n "$NODES_PER_REPLICA" ]] && LB_ARGS+=(--nodes-per-replica "$NODES_PER_REPLICA")
-  echo "Starting load balancer for ${#SERVE_JOBS[@]} replicas..."
+  if [[ ${#SERVE_JOBS[@]} -eq 0 ]]; then
+    echo "Starting load balancer with auto-discovery every ${DISCOVER_INTERVAL}s..."
+  else
+    echo "Starting load balancer for ${#SERVE_JOBS[@]} replicas..."
+  fi
   uv run --no-sync python serve/load_balancer.py "${LB_ARGS[@]}" &
   LB_PID=$!
 

--- a/serve/load_balancer.py
+++ b/serve/load_balancer.py
@@ -27,6 +27,8 @@ import logging
 import os
 import re
 import sys
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
 from pathlib import Path
 
 import httpx
@@ -146,45 +148,204 @@ async def resubmit_serve_job(
 
 
 # ---------------------------------------------------------------------------
-# Backend pool (thread-safe, dynamic add/remove)
+# Backend discovery and pool state
 # ---------------------------------------------------------------------------
 
 
+@dataclass
+class SlurmJob:
+    """Minimal Slurm job metadata needed for backend discovery."""
+
+    job_id: str
+    name: str
+    state: str
+
+
+@dataclass
+class Backend:
+    """One vLLM backend tracked by Slurm job ID."""
+
+    job_id: str
+    url: str
+    source: str
+    active_requests: int = 0
+    draining: bool = False
+    state: str = "RUNNING"
+    last_error: str = ""
+
+
+@dataclass
+class BackendLease:
+    """A checked-out backend plus the URL selected for one request."""
+
+    job_id: str
+    url: str
+
+
+def slugify(value: str) -> str:
+    """Match serve.slurm's job-name slug for model keys."""
+    slug = re.sub(r"[^A-Za-z0-9]+", "-", value).strip("-")
+    return re.sub(r"-+", "-", slug)
+
+
+async def discover_slurm_serve_jobs(model: str | None) -> list[SlurmJob]:
+    """Return alive vLLM serve jobs visible in Slurm for this user."""
+    proc = await asyncio.create_subprocess_exec(
+        "squeue",
+        "-u",
+        os.environ["USER"],
+        "--noheader",
+        "--format=%i|%j|%T",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await proc.communicate()
+    if proc.returncode != 0:
+        logger.warning("squeue discovery failed: %s", stderr.decode().strip())
+        return []
+
+    expected_suffix = slugify(model) if model else ""
+    jobs: list[SlurmJob] = []
+    for raw_line in stdout.decode().splitlines():
+        parts = raw_line.strip().split("|", 2)
+        if len(parts) != 3:
+            continue
+        job_id, name, state = parts
+        if not name.startswith("vllm-serve-"):
+            continue
+        if expected_suffix and name != f"vllm-serve-{expected_suffix}":
+            continue
+        if state not in SLURM_ALIVE_STATES:
+            continue
+        jobs.append(SlurmJob(job_id=job_id, name=name, state=state))
+    return jobs
+
+
 class BackendPool:
-    """Dynamic pool of healthy backend URLs with round-robin dispatch."""
+    """Dynamic pool of healthy backend URLs with draining and request counts."""
 
     def __init__(self) -> None:
-        self._urls: list[str] = []
+        self._backends: dict[str, Backend] = {}
         self._lock = asyncio.Lock()
         self._idx: int = 0
         self._ready = asyncio.Event()
 
-    async def add(self, url: str) -> None:
+    async def add(self, job_id: str, url: str, source: str = "configured") -> bool:
+        """Add or refresh a backend. Returns True when a new backend joined."""
         async with self._lock:
-            if url not in self._urls:
-                self._urls.append(url)
-                logger.info("Pool +backend: %s (pool size: %d)", url, len(self._urls))
-                self._ready.set()
+            for existing_id, backend in list(self._backends.items()):
+                if backend.url == url and existing_id != job_id:
+                    del self._backends[existing_id]
+                    logger.warning(
+                        "Pool -backend: %s job=%s replaced_by=%s",
+                        url,
+                        existing_id,
+                        job_id,
+                    )
 
-    async def remove(self, url: str) -> None:
+            if job_id in self._backends:
+                backend = self._backends[job_id]
+                backend.url = url
+                backend.source = source
+                backend.state = "RUNNING"
+                backend.last_error = ""
+                if not backend.draining:
+                    self._ready.set()
+                return False
+
+            self._backends[job_id] = Backend(job_id=job_id, url=url, source=source)
+            logger.info(
+                "Pool +backend: %s job=%s source=%s (pool size: %d)",
+                url,
+                job_id,
+                source,
+                len(self._backends),
+            )
+            self._ready.set()
+            return True
+
+    async def remove(self, job_id: str, reason: str) -> None:
         async with self._lock:
-            if url in self._urls:
-                self._urls.remove(url)
+            backend = self._backends.pop(job_id, None)
+            if backend is None:
+                return
+            logger.warning(
+                "Pool -backend: %s job=%s reason=%s (pool size: %d)",
+                backend.url,
+                job_id,
+                reason,
+                len(self._backends),
+            )
+
+    async def mark_draining(self, job_id: str, reason: str) -> bool:
+        """Stop assigning new work to a backend while in-flight work drains."""
+        async with self._lock:
+            if job_id not in self._backends:
+                return False
+            backend = self._backends[job_id]
+            if not backend.draining:
+                backend.draining = True
+                backend.last_error = reason
                 logger.warning(
-                    "Pool -backend: %s (pool size: %d)", url, len(self._urls)
+                    "Pool draining backend: %s job=%s active=%d reason=%s",
+                    backend.url,
+                    job_id,
+                    backend.active_requests,
+                    reason,
                 )
+            return True
 
-    async def next_url(self) -> str | None:
+    async def acquire(self) -> BackendLease | None:
+        """Choose a non-draining backend and increment its in-flight count."""
         async with self._lock:
-            if not self._urls:
+            active_ids = [
+                job_id
+                for job_id, backend in self._backends.items()
+                if not backend.draining
+            ]
+            if not active_ids:
                 return None
-            url = self._urls[self._idx % len(self._urls)]
+            job_id = active_ids[self._idx % len(active_ids)]
             self._idx += 1
-            return url
+            backend = self._backends[job_id]
+            backend.active_requests += 1
+            return BackendLease(job_id=job_id, url=backend.url)
 
-    async def all_urls(self) -> list[str]:
+    async def release(self, job_id: str) -> None:
         async with self._lock:
-            return list(self._urls)
+            if job_id not in self._backends:
+                return
+            backend = self._backends[job_id]
+            backend.active_requests = max(0, backend.active_requests - 1)
+
+    async def active_count(self, job_id: str) -> int:
+        async with self._lock:
+            if job_id not in self._backends:
+                return 0
+            return self._backends[job_id].active_requests
+
+    async def available_count(self) -> int:
+        async with self._lock:
+            return sum(1 for backend in self._backends.values() if not backend.draining)
+
+    async def known_job_ids(self) -> set[str]:
+        async with self._lock:
+            return set(self._backends)
+
+    async def snapshot(self) -> list[dict[str, str | int | bool]]:
+        async with self._lock:
+            return [
+                {
+                    "job_id": backend.job_id,
+                    "url": backend.url,
+                    "source": backend.source,
+                    "active_requests": backend.active_requests,
+                    "draining": backend.draining,
+                    "state": backend.state,
+                    "last_error": backend.last_error,
+                }
+                for backend in self._backends.values()
+            ]
 
     async def wait_for_first(self) -> None:
         """Block until at least one backend is available."""
@@ -192,8 +353,7 @@ class BackendPool:
 
     @property
     def size(self) -> int:
-        return len(self._urls)
-
+        return len(self._backends)
 
 # ---------------------------------------------------------------------------
 # Per-slot backend lifecycle manager
@@ -295,6 +455,17 @@ async def _wait_for_health(job_id: str, url: str, timeout: int) -> bool:
                 logger.info("  %s still waiting (%ds)...", health_url, elapsed)
 
 
+async def _is_healthy_now(url: str) -> bool:
+    """Return whether a backend is healthy right now without waiting."""
+    health_url = url.replace("/v1", "/health")
+    try:
+        async with httpx.AsyncClient(timeout=5) as client:
+            resp = await client.get(health_url)
+    except (httpx.ConnectError, httpx.ReadTimeout, httpx.ConnectTimeout):
+        return False
+    return resp.status_code == 200
+
+
 async def manage_backend_slot(
     initial_job_id: str,
     pool: BackendPool,
@@ -354,13 +525,13 @@ async def manage_backend_slot(
             return
 
         # 3) Add to pool and monitor
-        await pool.add(url)
+        await pool.add(current_jid, url)
         while await is_slurm_job_alive(current_jid):
             await asyncio.sleep(monitor_interval)
 
         # 4) Job died during operation — remove and maybe resubmit
         logger.warning("Job %s died while serving", current_jid)
-        await pool.remove(url)
+        await pool.remove(current_jid, "slurm job ended")
 
         if model and resubmits < max_resubmits:
             new_jid = await resubmit_serve_job(model, nodes_per_replica)
@@ -379,6 +550,46 @@ async def manage_backend_slot(
         return
 
 
+async def discover_backends_loop(
+    model: str,
+    pool: BackendPool,
+    interval: int,
+    monitor_interval: int,
+) -> None:
+    """Periodically discover alive Slurm serve jobs and attach healthy ones."""
+    while True:
+        jobs = await discover_slurm_serve_jobs(model)
+        known = await pool.known_job_ids()
+        for job in jobs:
+            if job.job_id in known:
+                continue
+            url = await _read_endpoint_env(job.job_id)
+            if url is None:
+                continue
+            if await _is_healthy_now(url):
+                joined = await pool.add(job.job_id, url, source="discovered")
+                if joined:
+                    asyncio.create_task(
+                        monitor_discovered_backend(
+                            job.job_id,
+                            pool,
+                            monitor_interval,
+                        )
+                    )
+        await asyncio.sleep(interval)
+
+
+async def monitor_discovered_backend(
+    job_id: str,
+    pool: BackendPool,
+    monitor_interval: int,
+) -> None:
+    """Remove a discovered backend when its Slurm job disappears."""
+    while await is_slurm_job_alive(job_id):
+        await asyncio.sleep(monitor_interval)
+    await pool.remove(job_id, "discovered slurm job ended")
+
+
 # ---------------------------------------------------------------------------
 # HTTP proxy
 # ---------------------------------------------------------------------------
@@ -392,48 +603,104 @@ def create_app(pool: BackendPool) -> Starlette:
     )
 
     async def health_check(request: Request) -> PlainTextResponse:
-        if pool.size > 0:
+        if await pool.available_count() > 0:
             return PlainTextResponse("OK")
         return PlainTextResponse("No healthy backends", status_code=503)
 
     async def pool_status(request: Request) -> JSONResponse:
-        urls = await pool.all_urls()
-        return JSONResponse({"backends": urls, "count": len(urls)})
+        backends = await pool.snapshot()
+        return JSONResponse({"backends": backends, "count": len(backends)})
+
+    async def drain_backend(request: Request) -> JSONResponse:
+        job_id = request.path_params["job_id"]
+        ok = await pool.mark_draining(job_id, "manual drain")
+        if not ok:
+            return JSONResponse({"error": f"unknown backend job {job_id}"}, status_code=404)
+        return JSONResponse({"job_id": job_id, "draining": True})
+
+    async def cancel_when_drained(request: Request) -> JSONResponse:
+        job_id = request.path_params["job_id"]
+        ok = await pool.mark_draining(job_id, "manual drain and cancel")
+        if not ok:
+            return JSONResponse({"error": f"unknown backend job {job_id}"}, status_code=404)
+
+        async def _cancel_after_drain() -> None:
+            while await pool.active_count(job_id) > 0:
+                await asyncio.sleep(5)
+            await cancel_slurm_job_if_alive(job_id, "manual drained scale-down")
+            await pool.remove(job_id, "manual drained scale-down")
+
+        asyncio.create_task(_cancel_after_drain())
+        return JSONResponse({"job_id": job_id, "draining": True, "cancel": "when_drained"})
 
     async def proxy(request: Request) -> StreamingResponse:
-        target_base = await pool.next_url()
-        if target_base is None:
-            return StreamingResponse(
-                content=iter([b"No healthy backends"]),
-                status_code=503,
-            )
-        target_url = target_base + request.url.path.removeprefix("/v1")
-        if request.url.query:
-            target_url += f"?{request.url.query}"
-
         body = await request.body()
         headers = dict(request.headers)
         headers.pop("host", None)
 
-        backend_request = client.build_request(
-            method=request.method,
-            url=target_url,
-            headers=headers,
-            content=body,
-        )
-        backend_response = await client.send(backend_request, stream=True)
+        last_error = "No healthy backends"
+        max_attempts = max(1, pool.size)
+        for _ in range(max_attempts):
+            lease = await pool.acquire()
+            if lease is None:
+                break
+
+            target_url = lease.url + request.url.path.removeprefix("/v1")
+            if request.url.query:
+                target_url += f"?{request.url.query}"
+
+            backend_request = client.build_request(
+                method=request.method,
+                url=target_url,
+                headers=headers,
+                content=body,
+            )
+            try:
+                backend_response = await client.send(backend_request, stream=True)
+            except (
+                httpx.ConnectError,
+                httpx.ConnectTimeout,
+                httpx.PoolTimeout,
+                httpx.RemoteProtocolError,
+            ) as exc:
+                last_error = f"{type(exc).__name__}: {exc}"
+                await pool.release(lease.job_id)
+                await pool.mark_draining(lease.job_id, last_error)
+                if await pool.active_count(lease.job_id) == 0:
+                    await pool.remove(lease.job_id, last_error)
+                continue
+
+            async def stream_response() -> AsyncIterator[bytes]:
+                try:
+                    async for chunk in backend_response.aiter_raw():
+                        yield chunk
+                except httpx.HTTPError as exc:
+                    await pool.mark_draining(
+                        lease.job_id,
+                        f"stream error: {type(exc).__name__}: {exc}",
+                    )
+                    raise
+                finally:
+                    await backend_response.aclose()
+                    await pool.release(lease.job_id)
+
+            return StreamingResponse(
+                content=stream_response(),
+                status_code=backend_response.status_code,
+                headers=dict(backend_response.headers),
+            )
 
         return StreamingResponse(
-            content=backend_response.aiter_raw(),
-            status_code=backend_response.status_code,
-            headers=dict(backend_response.headers),
-            background=backend_response.aclose,
+            content=iter([last_error.encode()]),
+            status_code=503,
         )
 
     return Starlette(
         routes=[
             Route("/health", health_check),
             Route("/status", pool_status),
+            Route("/drain/{job_id}", drain_backend, methods=["POST"]),
+            Route("/cancel_when_drained/{job_id}", cancel_when_drained, methods=["POST"]),
             Mount(
                 "/v1",
                 routes=[
@@ -467,11 +734,32 @@ async def main_async(args: argparse.Namespace) -> int:
         )
         for jid in args.job_ids
     ]
+    discovery_task = None
+    if args.model and args.discover_interval > 0:
+        discovery_task = asyncio.create_task(
+            discover_backends_loop(
+                args.model,
+                pool,
+                args.discover_interval,
+                args.monitor_interval,
+            )
+        )
+        logger.info(
+            "Backend auto-discovery enabled for model %s every %ds.",
+            args.model,
+            args.discover_interval,
+        )
 
     # Wait for at least one backend to become healthy before serving.
-    logger.info("Waiting for first healthy backend (%d slots)...", len(slot_tasks))
+    logger.info(
+        "Waiting for first healthy backend (%d configured slots, discovery=%s)...",
+        len(slot_tasks),
+        "on" if discovery_task else "off",
+    )
     wait_task = asyncio.create_task(pool.wait_for_first())
     pending: set[asyncio.Task] = {wait_task, *slot_tasks}
+    if discovery_task:
+        pending.add(discovery_task)
     while wait_task in pending:
         done, pending = await asyncio.wait(
             pending,
@@ -504,7 +792,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description="Resilient load balancer for multiple vLLM replicas."
     )
-    parser.add_argument("job_ids", nargs="+", help="SLURM serve job IDs")
+    parser.add_argument("job_ids", nargs="*", help="SLURM serve job IDs")
     parser.add_argument(
         "--port",
         type=int,
@@ -541,7 +829,18 @@ def main() -> None:
         default=60,
         help="Seconds between SLURM liveness checks (default: 60).",
     )
+    parser.add_argument(
+        "--discover-interval",
+        type=int,
+        default=600,
+        help=(
+            "Seconds between Slurm scans for new matching vLLM serve jobs "
+            "(default: 600; 0 disables)."
+        ),
+    )
     args = parser.parse_args()
+    if not args.job_ids and not args.model:
+        parser.error("provide at least one job ID or --model for auto-discovery")
     sys.exit(asyncio.run(main_async(args)))
 
 

--- a/serve/load_balancer.py
+++ b/serve/load_balancer.py
@@ -32,11 +32,6 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import httpx
-import uvicorn
-from starlette.applications import Starlette
-from starlette.requests import Request
-from starlette.responses import JSONResponse, PlainTextResponse, StreamingResponse
-from starlette.routing import Mount, Route
 
 logger = logging.getLogger("load_balancer")
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
@@ -355,6 +350,7 @@ class BackendPool:
     def size(self) -> int:
         return len(self._backends)
 
+
 # ---------------------------------------------------------------------------
 # Per-slot backend lifecycle manager
 # ---------------------------------------------------------------------------
@@ -595,7 +591,18 @@ async def monitor_discovered_backend(
 # ---------------------------------------------------------------------------
 
 
-def create_app(pool: BackendPool) -> Starlette:
+def create_app(pool: BackendPool):
+    """Create the Starlette proxy app.
+
+    Starlette/uvicorn are imported lazily so unit tests can import backend-state
+    helpers in the default CI environment, which does not install the local vLLM
+    serving extra.
+    """
+    from starlette.applications import Starlette
+    from starlette.requests import Request
+    from starlette.responses import JSONResponse, PlainTextResponse, StreamingResponse
+    from starlette.routing import Mount, Route
+
     # Max-think responses can stay silent for more than 10 minutes before the
     # backend emits a body chunk, so only bound connection setup and writes.
     client = httpx.AsyncClient(
@@ -615,14 +622,18 @@ def create_app(pool: BackendPool) -> Starlette:
         job_id = request.path_params["job_id"]
         ok = await pool.mark_draining(job_id, "manual drain")
         if not ok:
-            return JSONResponse({"error": f"unknown backend job {job_id}"}, status_code=404)
+            return JSONResponse(
+                {"error": f"unknown backend job {job_id}"}, status_code=404
+            )
         return JSONResponse({"job_id": job_id, "draining": True})
 
     async def cancel_when_drained(request: Request) -> JSONResponse:
         job_id = request.path_params["job_id"]
         ok = await pool.mark_draining(job_id, "manual drain and cancel")
         if not ok:
-            return JSONResponse({"error": f"unknown backend job {job_id}"}, status_code=404)
+            return JSONResponse(
+                {"error": f"unknown backend job {job_id}"}, status_code=404
+            )
 
         async def _cancel_after_drain() -> None:
             while await pool.active_count(job_id) > 0:
@@ -631,7 +642,9 @@ def create_app(pool: BackendPool) -> Starlette:
             await pool.remove(job_id, "manual drained scale-down")
 
         asyncio.create_task(_cancel_after_drain())
-        return JSONResponse({"job_id": job_id, "draining": True, "cancel": "when_drained"})
+        return JSONResponse(
+            {"job_id": job_id, "draining": True, "cancel": "when_drained"}
+        )
 
     async def proxy(request: Request) -> StreamingResponse:
         body = await request.body()
@@ -700,7 +713,9 @@ def create_app(pool: BackendPool) -> Starlette:
             Route("/health", health_check),
             Route("/status", pool_status),
             Route("/drain/{job_id}", drain_backend, methods=["POST"]),
-            Route("/cancel_when_drained/{job_id}", cancel_when_drained, methods=["POST"]),
+            Route(
+                "/cancel_when_drained/{job_id}", cancel_when_drained, methods=["POST"]
+            ),
             Mount(
                 "/v1",
                 routes=[
@@ -782,6 +797,8 @@ async def main_async(args: argparse.Namespace) -> int:
     )
 
     app = create_app(pool)
+    import uvicorn
+
     config = uvicorn.Config(app, host="0.0.0.0", port=args.port, log_level="info")
     server = uvicorn.Server(config)
     await server.serve()

--- a/tests/test_load_balancer.py
+++ b/tests/test_load_balancer.py
@@ -1,0 +1,85 @@
+"""Tests for dynamic load-balancer backend state."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from serve.load_balancer import BackendPool, slugify  # noqa: E402
+from serve.drain_backends import discover_eval_job  # noqa: E402
+
+
+def test_slugify_matches_serve_job_names() -> None:
+    """Model keys map to the same slug shape used in Slurm job names."""
+    assert slugify("deepseek-ai/DeepSeek-V4-Pro") == "deepseek-ai-DeepSeek-V4-Pro"
+    assert slugify("zai-org/GLM-5.1-runai") == "zai-org-GLM-5-1-runai"
+
+
+def test_backend_pool_draining_stops_new_assignments() -> None:
+    """Drained backends finish existing work but stop receiving new requests."""
+
+    async def scenario() -> None:
+        pool = BackendPool()
+        await pool.add("1", "http://one:8000/v1")
+        await pool.add("2", "http://two:8000/v1")
+
+        first = await pool.acquire()
+        assert first is not None
+        await pool.mark_draining(first.job_id, "test")
+
+        seen = []
+        for _ in range(4):
+            lease = await pool.acquire()
+            assert lease is not None
+            seen.append(lease.job_id)
+            await pool.release(lease.job_id)
+
+        assert seen == ["2", "2", "2", "2"]
+        assert await pool.active_count(first.job_id) == 1
+        await pool.release(first.job_id)
+        assert await pool.active_count(first.job_id) == 0
+
+    asyncio.run(scenario())
+
+
+def test_backend_pool_deduplicates_reused_urls() -> None:
+    """A new Slurm job reusing a URL replaces the stale job entry."""
+
+    async def scenario() -> None:
+        pool = BackendPool()
+        await pool.add("old", "http://host:8000/v1")
+        await pool.add("new", "http://host:8000/v1", source="discovered")
+
+        snapshot = await pool.snapshot()
+        assert len(snapshot) == 1
+        backend = snapshot[0]
+        assert backend["job_id"] == "new"
+        assert backend["source"] == "discovered"
+
+    asyncio.run(scenario())
+
+
+def test_discover_eval_job_requires_explicit_job_when_multiple(monkeypatch) -> None:
+    """Ambiguous eval-job discovery asks the operator to pass --eval-job."""
+
+    class Result:
+        returncode = 0
+        stdout = (
+            "111|critpt-physicsintern-deepseek-ai-DeepSeek-V4-Pro|RUNNING\n"
+            "222|critpt-physicsintern-deepseek-ai-DeepSeek-V4-Pro|RUNNING\n"
+        )
+        stderr = ""
+
+    monkeypatch.setenv("USER", "joel")
+    monkeypatch.setattr("serve.drain_backends._run_command", lambda cmd: Result())
+
+    try:
+        discover_eval_job()
+    except RuntimeError as exc:
+        assert "--eval-job" in str(exc)
+    else:
+        raise AssertionError("discover_eval_job should reject ambiguous eval jobs")


### PR DESCRIPTION
## Summary

This PR makes the vLLM load-balancing flow elastic so a running CritPt evaluation
can scale inference capacity up and down without restarting the eval job.

The load balancer can now discover matching Slurm `vllm-serve-<model>` jobs,
attach healthy endpoints dynamically, expose richer backend state, and drain
backends before cancellation. This supports the intended operating model for
large DeepSeek V4 runs: add replicas when the H100 cluster is empty, and release
capacity gracefully when the cluster fills back up.

## What Changed

- Added Slurm-based backend discovery in `serve/load_balancer.py`.
  - Scans for running matching `vllm-serve-<model>` jobs.
  - Reads `serve/logs/vllm/<job_id>/endpoint.env`.
  - Health-checks candidate endpoints before adding them.
  - Runs periodically via `--discover-interval` (`600` seconds by default).

- Reworked backend tracking from URL-only state to Slurm-job-aware state.
  - Tracks `job_id`, endpoint URL, source (`configured` or `discovered`),
    active request count, draining state, Slurm state, and last error.
  - `/status` now returns structured per-backend metadata instead of only URLs.

- Added graceful scale-down support.
  - `POST /drain/{job_id}` stops assigning new requests to a backend.
  - `POST /cancel_when_drained/{job_id}` drains the backend and calls `scancel`
    only after active requests reach zero.
  - The proxy retries another backend when connection setup fails before any
    response stream is returned, and quarantines bad backends.

- Updated `serve/full_eval.slurm`.
  - It can now start without explicit `--serve-job` arguments.
  - With zero serve job IDs it starts the load balancer in discovery-only mode
    and waits for the first healthy matching backend.
  - It forwards `--discover-interval` to the load balancer.

- Added `serve/drain_backends.py`.
  - Accepts one or more backend Slurm job IDs.
  - Auto-detects the single running `critpt-physicsintern-*` eval job when
    possible.
  - Calls the eval job's local load-balancer endpoint through
    `srun --overlap`.
  - Supports `--eval-job` for explicit targeting and `--status` for a post-drain
    pool snapshot.

- Documented the elastic scale-up/down workflow in `DOCUMENTATION.md` and added
  a concise README note for discovery-only full eval runs.

## Why

DeepSeek V4 replicas are expensive multi-node H100 jobs. Previously the running
eval job only knew about the backend job IDs passed at startup. That made it
awkward to opportunistically add capacity after the eval started, and direct
`scancel` scale-down could kill in-flight requests.

With this PR, the load balancer becomes the control plane for inference capacity:
new replicas can be launched independently and discovered automatically, while
old replicas can be drained before Slurm cancellation.

## Operational Notes

Start a discovery-only eval:

```bash
./serve/full_eval.slurm \
  --model deepseek-ai/DeepSeek-V4-Pro \
  --runner physicsintern \
  --config config.cluster.yaml \
  --resume results/critpt/deepseek-ai-DeepSeek-V4-Pro/<RUN_DIR> \
  --workspace-base workspaces_deepseek_v4_pro_max_think_4replica_20260507 \
  --nodes-per-replica 4 \
  --concurrency 64 \
  --time 24:00:00 \
  --keep-serves
```

Gracefully free backend capacity:

```bash
./serve/drain_backends.py <BACKEND_JOB_ID> [<BACKEND_JOB_ID> ...] --status
```

If multiple eval jobs are running:

```bash
./serve/drain_backends.py \
  --eval-job <EVAL_JOB_ID> \
  <BACKEND_JOB_ID_1> <BACKEND_JOB_ID_2> \
  --status
```

Direct `scancel <BACKEND_JOB_ID>` still works, but it is not request-aware and
can interrupt active generations. Use the drain helper for normal scale-down.

## Test Plan

- `uv run --no-sync python -m pytest -q ./tests/`
- `uv run --no-sync ruff check tests src scripts serve`
- `uv run --no-sync ruff format --check tests src scripts serve`
- `python -m py_compile serve/load_balancer.py serve/drain_backends.py`
- `bash -n serve/full_eval.slurm`

## Live Validation

- Started a discovery-only load balancer against currently running DeepSeek V4
  serve jobs.
- Verified it discovered the seven healthy running backends without explicit job
  IDs.
- Verified the crashed backend was not added because its endpoint failed health
  checks.
- Restarted the live CritPt eval in discovery-only mode and confirmed the new
  load balancer attached healthy backends and served `/v1/chat/completions`
  traffic.