### PR TITLE
Throttle load balancer backend requests

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -395,6 +395,15 @@ replicas when the cluster is empty and have the running evaluation pick them up
 automatically. If no `--serve-job` is passed to `serve/full_eval.slurm`, the eval
 starts in discovery-only mode and waits for the first matching healthy backend.
 
+The load balancer caps active requests per backend to avoid overloading DeepSeek
+replicas as the backend count changes. `serve/full_eval.slurm` defaults to
+`--max-active-per-backend 8` and `--queue-timeout 1800`: requests above the
+current healthy-backend capacity wait in the load balancer instead of being sent
+to an already saturated backend. When auto-discovery adds new replicas, capacity
+increases automatically; when a backend is drained or dies, new requests wait for
+the remaining capacity. The cluster eval config sets `api_timeout: 3600` so
+queued requests have enough client-side timeout headroom.
+
 To free capacity, do not call `scancel` directly unless you are willing to kill
 in-flight requests. Use the drain helper so the backend receives no new requests
 and is cancelled only after its active request count reaches zero:

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ uv sync --extra local
 # formatter-rejection artifacts before granting an unfinished workspace more budget.
 # If no --serve-job is provided, the load balancer discovers matching running
 # vLLM serve jobs from Slurm every 10 minutes and adds healthy backends.
+# Full evaluations default to a 3-day Slurm time limit.
+# The load balancer caps active requests per backend (default: 8) and queues
+# overflow requests so newly discovered backends increase capacity safely.
 ./serve/full_eval.slurm --model deepseek-ai/DeepSeek-V4-Pro --serve-job <JOB_ID>
 
 # Run a research problem (requires model API key in .env or env var)

--- a/config.cluster.yaml
+++ b/config.cluster.yaml
@@ -1,2 +1,3 @@
 max_wall_seconds: 86400  # 24h
 max_total_output_tokens: 2000000
+api_timeout: 3600

--- a/scripts/run_critpt_physics_intern.py
+++ b/scripts/run_critpt_physics_intern.py
@@ -211,26 +211,59 @@ def _is_formatter_rejection_answer(answer_text: str) -> bool:
     return answer_text.strip().startswith(FORMATTER_REJECTION_PREFIX)
 
 
+def _git_tracks_path(workspace: Path, relative_path: str) -> bool:
+    """Return whether a path is tracked in the workspace git repository."""
+    proc = subprocess.run(
+        ["git", "ls-files", "--error-unmatch", relative_path],
+        cwd=str(workspace),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return proc.returncode == 0
+
+
 def _commit_answer_cleanup_before_resume(workspace: Path, reason: str) -> None:
-    """Remove an invalid final answer and commit that cleanup before resume.
+    """Remove invalid completion artifacts and commit cleanup before resume.
 
     ``physics_intern.main --resume`` refuses any workspace with ``ANSWER.md``
     because that file is the canonical completion signal. Empty or explicit
     formatter-rejection answers are not valid submissions, so the batch runner
     removes them and records the cleanup in the challenge workspace git history
     before granting more budget.
+
+    A formatter can also fail after marking the research graph as completed. In
+    that state resume exits immediately without producing an answer, so reopen
+    the graph whenever there is no valid final answer.
     """
     answer_path = workspace / "ANSWER.md"
-    if not answer_path.exists():
+    graph_path = workspace / "RESEARCH_GRAPH.json"
+    changed = False
+    stage_paths: list[str] = []
+
+    if answer_path.exists():
+        answer_was_tracked = _git_tracks_path(workspace, "ANSWER.md")
+        answer_text = answer_path.read_text()
+        if answer_text.strip() and not _is_formatter_rejection_answer(answer_text):
+            return
+        answer_path.unlink()
+        changed = True
+        if answer_was_tracked:
+            stage_paths.append("ANSWER.md")
+
+    if graph_path.exists():
+        graph_data = json.loads(graph_path.read_text())
+        if graph_data["status"] == "completed":
+            graph_data["status"] = "in_progress"
+            graph_path.write_text(json.dumps(graph_data, indent=2, ensure_ascii=False))
+            changed = True
+            stage_paths.append("RESEARCH_GRAPH.json")
+
+    if not changed or not stage_paths:
         return
 
-    answer_text = answer_path.read_text()
-    if answer_text.strip() and not _is_formatter_rejection_answer(answer_text):
-        return
-
-    answer_path.unlink()
     add_proc = subprocess.run(
-        ["git", "add", "-A", "ANSWER.md"],
+        ["git", "add", "-A", "--", *stage_paths],
         cwd=str(workspace),
         capture_output=True,
         text=True,
@@ -243,7 +276,7 @@ def _commit_answer_cleanup_before_resume(workspace: Path, reason: str) -> None:
         )
 
     status_proc = subprocess.run(
-        ["git", "status", "--porcelain", "--", "ANSWER.md"],
+        ["git", "status", "--porcelain", "--", "ANSWER.md", "RESEARCH_GRAPH.json"],
         cwd=str(workspace),
         capture_output=True,
         text=True,
@@ -317,6 +350,11 @@ def plan_actions(
             # Workspace exists but no valid answer — try to resume
             graph_path = ws / "RESEARCH_GRAPH.json"
             if graph_path.exists():
+                graph_data = json.loads(graph_path.read_text())
+                if graph_data["status"] == "completed":
+                    cleanup_answer_before_resume = True
+                    if not cleanup_answer_reason:
+                        cleanup_answer_reason = "completed graph without valid answer"
                 actions.append(
                     ResumeAction(
                         problem=p,

--- a/serve/full_eval.slurm
+++ b/serve/full_eval.slurm
@@ -38,7 +38,7 @@ LOG_DIR_DEFAULT="${LOG_ROOT}/slurm"
 MODEL_KEY=""
 SERVE_JOBS=()
 CONCURRENCY="64"
-TIME_LIMIT="08:00:00"
+TIME_LIMIT="3-00:00:00"
 RESUME_DIR=""
 RUNNER="oneshot"
 CONFIG_FILE=""
@@ -48,6 +48,8 @@ NODES_PER_REPLICA=""
 KEEP_SERVES=""
 PARTITION="hopper-cpu"
 DISCOVER_INTERVAL="600"
+MAX_ACTIVE_PER_BACKEND="8"
+QUEUE_TIMEOUT="1800"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -64,6 +66,8 @@ while [[ $# -gt 0 ]]; do
     --keep-serves) KEEP_SERVES="1"; shift ;;
     --partition) PARTITION="$2"; shift 2 ;;
     --discover-interval) DISCOVER_INTERVAL="$2"; shift 2 ;;
+    --max-active-per-backend) MAX_ACTIVE_PER_BACKEND="$2"; shift 2 ;;
+    --queue-timeout) QUEUE_TIMEOUT="$2"; shift 2 ;;
     *) echo "Unknown argument: $1" >&2; exit 1 ;;
   esac
 done
@@ -75,6 +79,7 @@ Usage: full_eval.slurm --model MODEL_KEY [--serve-job JOB_ID [--serve-job JOB_ID
        [--runner oneshot|physicsintern] [--config CONFIG.yaml]
        [--fresh] [--workspace-base DIR] [--nodes-per-replica N]
        [--partition PARTITION] [--discover-interval SECONDS]
+       [--max-active-per-backend N] [--queue-timeout SECONDS]
 USAGE
   exit 1
 fi
@@ -125,6 +130,11 @@ if [[ -z "${SLURM_JOB_ID:-}" ]]; then
   KS_ARG=()
   [[ -n "$KEEP_SERVES" ]] && KS_ARG=(--keep-serves)
 
+  LB_LIMIT_ARGS=(
+    --max-active-per-backend "$MAX_ACTIVE_PER_BACKEND"
+    --queue-timeout "$QUEUE_TIMEOUT"
+  )
+
   SERVE_JOB_ARGS=()
   for jid in "${SERVE_JOBS[@]}"; do
     SERVE_JOB_ARGS+=(--serve-job "$jid")
@@ -148,7 +158,8 @@ if [[ -z "${SLURM_JOB_ID:-}" ]]; then
                    "${NPR_ARG[@]}" \
                    "${KS_ARG[@]}" \
                    --partition "$PARTITION" \
-                   --discover-interval "$DISCOVER_INTERVAL"
+                   --discover-interval "$DISCOVER_INTERVAL" \
+                   "${LB_LIMIT_ARGS[@]}"
 fi
 
 # ── Inside Slurm ─────────────────────────────────────────────────────────────
@@ -179,7 +190,15 @@ trap cleanup EXIT
 
 if [[ ${#SERVE_JOBS[@]} -ne 1 ]]; then
   # Multi-replica: start load balancer and wait for it
-  LB_ARGS=("${SERVE_JOBS[@]}" --port 9000 --health-timeout 3600 --model "$MODEL_KEY" --discover-interval "$DISCOVER_INTERVAL")
+  LB_ARGS=(
+    "${SERVE_JOBS[@]}"
+    --port 9000
+    --health-timeout 3600
+    --model "$MODEL_KEY"
+    --discover-interval "$DISCOVER_INTERVAL"
+    --max-active-per-backend "$MAX_ACTIVE_PER_BACKEND"
+    --queue-timeout "$QUEUE_TIMEOUT"
+  )
   [[ -n "$NODES_PER_REPLICA" ]] && LB_ARGS+=(--nodes-per-replica "$NODES_PER_REPLICA")
   if [[ ${#SERVE_JOBS[@]} -eq 0 ]]; then
     echo "Starting load balancer with auto-discovery every ${DISCOVER_INTERVAL}s..."

--- a/serve/load_balancer.py
+++ b/serve/load_balancer.py
@@ -374,9 +374,13 @@ class BackendPool:
                     "available_request_slots": (
                         0
                         if backend.draining
-                        else max(
-                            0,
-                            self._max_active_per_backend - backend.active_requests,
+                        else (
+                            -1
+                            if self._max_active_per_backend == 0
+                            else max(
+                                0,
+                                self._max_active_per_backend - backend.active_requests,
+                            )
                         )
                     ),
                     "draining": backend.draining,
@@ -393,7 +397,7 @@ class BackendPool:
     async def total_capacity(self) -> int:
         async with self._lock:
             if self._max_active_per_backend == 0:
-                return 0
+                return -1
             return sum(
                 self._max_active_per_backend
                 for backend in self._backends.values()
@@ -718,8 +722,17 @@ def create_app(pool: BackendPool, queue_timeout: float | None = None):
 
         last_error = "No healthy backends"
         max_attempts = max(1, pool.size)
+        start_time = asyncio.get_event_loop().time()
         for _ in range(max_attempts):
-            lease = await pool.acquire(timeout=queue_timeout)
+            if queue_timeout is not None:
+                elapsed = asyncio.get_event_loop().time() - start_time
+                remaining_timeout = max(0.0, queue_timeout - elapsed)
+                if remaining_timeout <= 0:
+                    last_error = "Timed out waiting for backend capacity"
+                    break
+                lease = await pool.acquire(timeout=remaining_timeout)
+            else:
+                lease = await pool.acquire(timeout=None)
             if lease is None:
                 last_error = "Timed out waiting for backend capacity"
                 break

--- a/serve/load_balancer.py
+++ b/serve/load_balancer.py
@@ -219,15 +219,35 @@ async def discover_slurm_serve_jobs(model: str | None) -> list[SlurmJob]:
 class BackendPool:
     """Dynamic pool of healthy backend URLs with draining and request counts."""
 
-    def __init__(self) -> None:
+    def __init__(self, max_active_per_backend: int = 0) -> None:
+        if max_active_per_backend < 0:
+            raise ValueError("max_active_per_backend must be >= 0")
         self._backends: dict[str, Backend] = {}
         self._lock = asyncio.Lock()
+        self._capacity_changed = asyncio.Condition(self._lock)
         self._idx: int = 0
         self._ready = asyncio.Event()
+        self._max_active_per_backend = max_active_per_backend
+        self._queued_requests = 0
+
+    def _has_free_capacity(self, backend: Backend) -> bool:
+        if backend.draining:
+            return False
+        return (
+            self._max_active_per_backend == 0
+            or backend.active_requests < self._max_active_per_backend
+        )
+
+    def _available_ids_locked(self) -> list[str]:
+        return [
+            job_id
+            for job_id, backend in self._backends.items()
+            if self._has_free_capacity(backend)
+        ]
 
     async def add(self, job_id: str, url: str, source: str = "configured") -> bool:
         """Add or refresh a backend. Returns True when a new backend joined."""
-        async with self._lock:
+        async with self._capacity_changed:
             for existing_id, backend in list(self._backends.items()):
                 if backend.url == url and existing_id != job_id:
                     del self._backends[existing_id]
@@ -246,6 +266,7 @@ class BackendPool:
                 backend.last_error = ""
                 if not backend.draining:
                     self._ready.set()
+                    self._capacity_changed.notify_all()
                 return False
 
             self._backends[job_id] = Backend(job_id=job_id, url=url, source=source)
@@ -257,10 +278,11 @@ class BackendPool:
                 len(self._backends),
             )
             self._ready.set()
+            self._capacity_changed.notify_all()
             return True
 
     async def remove(self, job_id: str, reason: str) -> None:
-        async with self._lock:
+        async with self._capacity_changed:
             backend = self._backends.pop(job_id, None)
             if backend is None:
                 return
@@ -271,10 +293,11 @@ class BackendPool:
                 reason,
                 len(self._backends),
             )
+            self._capacity_changed.notify_all()
 
     async def mark_draining(self, job_id: str, reason: str) -> bool:
         """Stop assigning new work to a backend while in-flight work drains."""
-        async with self._lock:
+        async with self._capacity_changed:
             if job_id not in self._backends:
                 return False
             backend = self._backends[job_id]
@@ -288,30 +311,42 @@ class BackendPool:
                     backend.active_requests,
                     reason,
                 )
+                self._capacity_changed.notify_all()
             return True
 
-    async def acquire(self) -> BackendLease | None:
-        """Choose a non-draining backend and increment its in-flight count."""
-        async with self._lock:
-            active_ids = [
-                job_id
-                for job_id, backend in self._backends.items()
-                if not backend.draining
-            ]
-            if not active_ids:
-                return None
-            job_id = active_ids[self._idx % len(active_ids)]
-            self._idx += 1
-            backend = self._backends[job_id]
-            backend.active_requests += 1
-            return BackendLease(job_id=job_id, url=backend.url)
+    async def acquire(self, timeout: float | None = None) -> BackendLease | None:
+        """Wait for a backend with free capacity and reserve one request slot."""
+
+        async def _wait_for_capacity() -> BackendLease:
+            async with self._capacity_changed:
+                self._queued_requests += 1
+                try:
+                    while True:
+                        active_ids = self._available_ids_locked()
+                        if active_ids:
+                            job_id = active_ids[self._idx % len(active_ids)]
+                            self._idx += 1
+                            backend = self._backends[job_id]
+                            backend.active_requests += 1
+                            return BackendLease(job_id=job_id, url=backend.url)
+                        await self._capacity_changed.wait()
+                finally:
+                    self._queued_requests = max(0, self._queued_requests - 1)
+
+        try:
+            if timeout is None:
+                return await _wait_for_capacity()
+            return await asyncio.wait_for(_wait_for_capacity(), timeout=timeout)
+        except TimeoutError:
+            return None
 
     async def release(self, job_id: str) -> None:
-        async with self._lock:
+        async with self._capacity_changed:
             if job_id not in self._backends:
                 return
             backend = self._backends[job_id]
             backend.active_requests = max(0, backend.active_requests - 1)
+            self._capacity_changed.notify_all()
 
     async def active_count(self, job_id: str) -> int:
         async with self._lock:
@@ -335,12 +370,35 @@ class BackendPool:
                     "url": backend.url,
                     "source": backend.source,
                     "active_requests": backend.active_requests,
+                    "max_active_requests": self._max_active_per_backend,
+                    "available_request_slots": (
+                        0
+                        if backend.draining
+                        else max(
+                            0,
+                            self._max_active_per_backend - backend.active_requests,
+                        )
+                    ),
                     "draining": backend.draining,
                     "state": backend.state,
                     "last_error": backend.last_error,
                 }
                 for backend in self._backends.values()
             ]
+
+    async def queued_count(self) -> int:
+        async with self._lock:
+            return self._queued_requests
+
+    async def total_capacity(self) -> int:
+        async with self._lock:
+            if self._max_active_per_backend == 0:
+                return 0
+            return sum(
+                self._max_active_per_backend
+                for backend in self._backends.values()
+                if not backend.draining
+            )
 
     async def wait_for_first(self) -> None:
         """Block until at least one backend is available."""
@@ -591,7 +649,7 @@ async def monitor_discovered_backend(
 # ---------------------------------------------------------------------------
 
 
-def create_app(pool: BackendPool):
+def create_app(pool: BackendPool, queue_timeout: float | None = None):
     """Create the Starlette proxy app.
 
     Starlette/uvicorn are imported lazily so unit tests can import backend-state
@@ -616,7 +674,14 @@ def create_app(pool: BackendPool):
 
     async def pool_status(request: Request) -> JSONResponse:
         backends = await pool.snapshot()
-        return JSONResponse({"backends": backends, "count": len(backends)})
+        return JSONResponse(
+            {
+                "backends": backends,
+                "count": len(backends),
+                "queued_requests": await pool.queued_count(),
+                "total_capacity": await pool.total_capacity(),
+            }
+        )
 
     async def drain_backend(request: Request) -> JSONResponse:
         job_id = request.path_params["job_id"]
@@ -654,8 +719,9 @@ def create_app(pool: BackendPool):
         last_error = "No healthy backends"
         max_attempts = max(1, pool.size)
         for _ in range(max_attempts):
-            lease = await pool.acquire()
+            lease = await pool.acquire(timeout=queue_timeout)
             if lease is None:
+                last_error = "Timed out waiting for backend capacity"
                 break
 
             target_url = lease.url + request.url.path.removeprefix("/v1")
@@ -732,7 +798,7 @@ def create_app(pool: BackendPool):
 
 
 async def main_async(args: argparse.Namespace) -> int:
-    pool = BackendPool()
+    pool = BackendPool(max_active_per_backend=args.max_active_per_backend)
 
     # Launch one manager task per backend slot (all run concurrently).
     slot_tasks = [
@@ -796,7 +862,7 @@ async def main_async(args: argparse.Namespace) -> int:
         args.port,
     )
 
-    app = create_app(pool)
+    app = create_app(pool, queue_timeout=args.queue_timeout)
     import uvicorn
 
     config = uvicorn.Config(app, host="0.0.0.0", port=args.port, log_level="info")
@@ -853,6 +919,22 @@ def main() -> None:
         help=(
             "Seconds between Slurm scans for new matching vLLM serve jobs "
             "(default: 600; 0 disables)."
+        ),
+    )
+    parser.add_argument(
+        "--max-active-per-backend",
+        type=int,
+        default=0,
+        help=(
+            "Maximum in-flight proxied requests per backend (default: 0 = unlimited)."
+        ),
+    )
+    parser.add_argument(
+        "--queue-timeout",
+        type=float,
+        default=1800.0,
+        help=(
+            "Seconds a proxied request may wait for backend capacity (default: 1800)."
         ),
     )
     args = parser.parse_args()

--- a/tests/test_load_balancer.py
+++ b/tests/test_load_balancer.py
@@ -63,6 +63,109 @@ def test_backend_pool_deduplicates_reused_urls() -> None:
     asyncio.run(scenario())
 
 
+def test_backend_pool_respects_per_backend_active_limit() -> None:
+    """A backend at its active request limit should not receive new work."""
+
+    async def scenario() -> None:
+        pool = BackendPool(max_active_per_backend=2)
+        await pool.add("1", "http://one:8000/v1")
+
+        first = await pool.acquire(timeout=0.01)
+        second = await pool.acquire(timeout=0.01)
+        assert first is not None
+        assert second is not None
+        assert first.job_id == "1"
+        assert second.job_id == "1"
+
+        saturated = await pool.acquire(timeout=0.01)
+        assert saturated is None
+
+        await pool.release(first.job_id)
+        next_lease = await pool.acquire(timeout=0.01)
+        assert next_lease is not None
+        assert next_lease.job_id == "1"
+
+    asyncio.run(scenario())
+
+
+def test_backend_pool_routes_only_to_backends_with_free_capacity() -> None:
+    """Round-robin selection should skip saturated and draining backends."""
+
+    async def scenario() -> None:
+        pool = BackendPool(max_active_per_backend=1)
+        await pool.add("1", "http://one:8000/v1")
+        await pool.add("2", "http://two:8000/v1")
+        await pool.add("3", "http://three:8000/v1")
+        await pool.mark_draining("3", "test")
+
+        first = await pool.acquire(timeout=0.01)
+        second = await pool.acquire(timeout=0.01)
+        assert first is not None
+        assert second is not None
+        assert {first.job_id, second.job_id} == {"1", "2"}
+
+        saturated = await pool.acquire(timeout=0.01)
+        assert saturated is None
+
+        await pool.release(first.job_id)
+        next_lease = await pool.acquire(timeout=0.01)
+        assert next_lease is not None
+        assert next_lease.job_id == first.job_id
+
+    asyncio.run(scenario())
+
+
+def test_backend_pool_acquire_waits_for_released_capacity() -> None:
+    """Queued requests should wait inside the load balancer for a free slot."""
+
+    async def scenario() -> None:
+        pool = BackendPool(max_active_per_backend=1)
+        await pool.add("1", "http://one:8000/v1")
+
+        first = await pool.acquire(timeout=0.01)
+        assert first is not None
+
+        waiter = asyncio.create_task(pool.acquire(timeout=1.0))
+        await asyncio.sleep(0.05)
+        assert not waiter.done()
+
+        await pool.release(first.job_id)
+        second = await waiter
+        assert second is not None
+        assert second.job_id == "1"
+
+    asyncio.run(scenario())
+
+
+def test_backend_pool_status_reports_queue_and_capacity() -> None:
+    """Status should expose enough data to tune adaptive backend capacity."""
+
+    async def scenario() -> None:
+        pool = BackendPool(max_active_per_backend=2)
+        await pool.add("1", "http://one:8000/v1")
+        lease = await pool.acquire(timeout=0.01)
+        assert lease is not None
+
+        snapshot = await pool.snapshot()
+        assert snapshot == [
+            {
+                "job_id": "1",
+                "url": "http://one:8000/v1",
+                "source": "configured",
+                "active_requests": 1,
+                "max_active_requests": 2,
+                "available_request_slots": 1,
+                "draining": False,
+                "state": "RUNNING",
+                "last_error": "",
+            }
+        ]
+        assert await pool.queued_count() == 0
+        assert await pool.total_capacity() == 2
+
+    asyncio.run(scenario())
+
+
 def test_discover_eval_job_requires_explicit_job_when_multiple(monkeypatch) -> None:
     """Ambiguous eval-job discovery asks the operator to pass --eval-job."""
 

--- a/tests/test_run_critpt_common.py
+++ b/tests/test_run_critpt_common.py
@@ -72,6 +72,70 @@ def _problem(n: int) -> Problem:
     )
 
 
+def test_cluster_config_uses_one_hour_api_timeout() -> None:
+    """Queued load-balancer requests need enough client timeout headroom."""
+    import yaml
+
+    config = yaml.safe_load((PROJECT_ROOT / "config.cluster.yaml").read_text())
+    assert config["api_timeout"] == 3600
+
+
+def test_plan_actions_reopens_completed_graph_without_answer(tmp_path):
+    """A completed graph without ANSWER.md must be resumed, not skipped."""
+    output_dir = tmp_path / "results"
+    output_dir.mkdir()
+    workspace_base = tmp_path / "workspaces"
+    safe_model = "deepseek-ai-DeepSeek-V4-Pro"
+    workspace = workspace_base / f"20260508_100000_Challenge_25_main_{safe_model}"
+    workspace.mkdir(parents=True)
+    (workspace / "RESEARCH_GRAPH.json").write_text('{"status": "completed"}')
+
+    actions = plan_actions(
+        problems=[_problem(25)],
+        output_dir=output_dir,
+        workspace_base=workspace_base,
+        model_key="deepseek-ai/DeepSeek-V4-Pro",
+        force=False,
+    )
+
+    assert len(actions) == 1
+    action = actions[0]
+    assert action.action == "resume"
+    assert action.workspace == workspace
+    assert action.cleanup_answer_before_resume is True
+    assert action.cleanup_answer_reason == "completed graph without valid answer"
+
+
+def test_commit_answer_cleanup_before_resume_reopens_completed_graph(tmp_path):
+    """Resume cleanup reopens completed workspaces that never produced an answer."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _init_git_repo(workspace)
+    (workspace / "RESEARCH_GRAPH.json").write_text('{"status": "completed"}')
+    subprocess.run(["git", "add", "-A"], cwd=workspace, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Completed graph"],
+        cwd=workspace,
+        capture_output=True,
+        check=True,
+    )
+
+    _commit_answer_cleanup_before_resume(
+        workspace, "completed graph without valid answer"
+    )
+
+    graph_data = json.loads((workspace / "RESEARCH_GRAPH.json").read_text())
+    assert graph_data["status"] == "in_progress"
+    status = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=workspace,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert status.stdout == ""
+
+
 def _init_git_repo(workspace: Path) -> None:
     """Initialise a test git repository that can create cleanup commits."""
     subprocess.run(["git", "init"], cwd=workspace, capture_output=True, check=True)


### PR DESCRIPTION
## Summary

This PR makes evaluation serving more robust when backend capacity changes
during a long CritPt run. The behavior is model-agnostic; the DeepSeek V4 run
was simply the incident that exposed the need for load-balancer-level
throttling.

The load balancer now owns request concurrency safety: it caps the number of
active proxied requests per backend and queues overflow requests until a backend
slot is available. This lets eval concurrency stay high while preventing a small
backend pool from being overloaded after scale-down or before newly launched
replicas have joined, regardless of which vLLM-served model is behind the pool.

## Changes

- Add load-balancer request throttling.
  - `BackendPool(max_active_per_backend=...)` tracks per-backend request slots.
  - Saturated and draining backends are skipped.
  - Overflow requests wait inside the load balancer until capacity is released.
  - Requests return 503 after `--queue-timeout` instead of waiting forever.
  - `/status` now reports `queued_requests`, `total_capacity`, and per-backend
    slot availability.

- Wire throttling into `serve/full_eval.slurm`.
  - Default full-eval Slurm time limit is now `3-00:00:00`.
  - Default load-balancer cap is `--max-active-per-backend 8`.
  - Default load-balancer queue timeout is `--queue-timeout 1800`.
  - Discovery remains enabled by default so additional matching backends can
    join a running eval.

- Increase the cluster eval client timeout.
  - `config.cluster.yaml` now sets `api_timeout: 3600` so queued requests have
    enough headroom before the client gives up.

- Fix a resume edge case observed on C25.
  - Empty/rejected-answer cleanup also reopens `RESEARCH_GRAPH.json` from
    `completed` to `in_progress` when no valid `ANSWER.md` exists.
  - This prevents completed-but-unanswered workspaces from being skipped on
    resume.

- Update README and documentation for the new serving behavior.

## Test Plan

- `uv run --no-sync python -m pytest tests/test_load_balancer.py tests/test_run_critpt_common.py -q`
- `uv run --no-sync ruff check serve/load_balancer.py tests/test_load_balancer.py tests/test_run_critpt_common.py`
- `uv run --no-sync ruff format --check serve/load_balancer.py tests/test_load_balancer.py tests/test_run_critpt_common.py`
- `python -m py_compile serve/load_balancer.py`
- `bash -n serve/full_eval.slurm`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request routing/queuing in the vLLM load balancer and updates Slurm eval defaults, which can affect long-running benchmark stability and throughput under load but is well-covered by new tests.
> 
> **Overview**
> Improves robustness of multi-replica vLLM evaluations by adding **per-backend request throttling and queueing** in `serve/load_balancer.py`: the balancer now reserves per-backend request slots, skips saturated/draining backends, waits for capacity with a configurable `--queue-timeout`, and exposes queue/capacity metrics via `/status`.
> 
> Wires the new limits into `serve/full_eval.slurm` (new `--max-active-per-backend`/`--queue-timeout` flags, defaults of 8 and 1800s) and increases the default eval Slurm time limit to **3 days**; `config.cluster.yaml` adds `api_timeout: 3600` to tolerate queued requests.
> 
> Fixes a resume edge case in `scripts/run_critpt_physics_intern.py` by reopening `RESEARCH_GRAPH.json` from `completed` to `in_progress` when there is no valid `ANSWER.md`, and updates docs/README plus adds focused tests for the new load balancer behavior and resume logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e52bab2468b32170cd5d1a0240f852b9fbfaa5cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->