### PR TITLE
Default CritPt Eval To Hopper Prod

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -475,10 +475,12 @@ Run the full PhysicsIntern CritPt sweep against four replicas with:
   --time 24:00:00
 ```
 
-`serve/full_eval.slurm` defaults the eval runner to `hopper-cpu` because it only
-hosts the load balancer and PhysicsIntern subprocesses; the vLLM serve replicas
-remain on their GPU partition. Use `--partition <name>` only if the eval runner
-needs a different Slurm partition.
+`serve/full_eval.slurm` defaults the eval runner to `hopper-prod` even though it
+only hosts the load balancer and PhysicsIntern subprocesses. The `hopper-cpu`
+partition uses spot nodes and can preempt long evaluations mid-run, while
+`hopper-prod` keeps the eval wrapper on the same stable partition as the vLLM
+serve replicas. Use `--partition <name>` only when you intentionally want a
+different Slurm partition.
 
 ### Prerequisites
 
@@ -666,7 +668,7 @@ The Python vLLM provider defaults to `http://localhost:8000/v1` but respects the
 
 ### Step 3 (optional): Full benchmark sweep
 
-To run the **entire CritPt set (70 problems) in parallel** against a vLLM serve job, use `serve/full_eval.slurm`. It self-submits the CPU-only eval runner to `hopper-cpu` by default, starts a load balancer when multiple serve jobs are provided, and auto-fans out via `scripts/run_critpt_oneshot.py`, with `--concurrency` parallel in-flight requests sharing the same endpoint:
+To run the **entire CritPt set (70 problems) in parallel** against a vLLM serve job, use `serve/full_eval.slurm`. It self-submits the eval runner to `hopper-prod` by default to avoid spot/preemption cancellations on `hopper-cpu`, starts a load balancer when multiple serve jobs are provided, and auto-fans out via `scripts/run_critpt_oneshot.py`, with `--concurrency` parallel in-flight requests sharing the same endpoint:
 
 ```bash
 ./serve/full_eval.slurm \

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ uv sync --extra local
 # Queued replacements wait without timing out; failed replacements are cancelled before resubmit.
 ./serve/serve.slurm --model deepseek-ai/DeepSeek-V4-Pro
 
-# Run full CritPt evaluation against existing serve jobs from the CPU partition.
+# Run full CritPt evaluation against existing serve jobs. The eval wrapper
+# defaults to hopper-prod to avoid spot/preemption cancellations on hopper-cpu.
 # Resume automatically reuses scoreable `ANSWER.md` files and removes empty or
 # formatter-rejection artifacts before granting an unfinished workspace more budget.
 # If no --serve-job is provided, the load balancer discovers matching running

--- a/serve/full_eval.slurm
+++ b/serve/full_eval.slurm
@@ -20,8 +20,9 @@
 #
 # Self-submits via sbatch when run outside Slurm. For multiple serve jobs, starts
 # a load_balancer.py in the background and routes all traffic through it. The
-# eval runner is CPU-only and defaults to hopper-cpu; serve jobs still run on
-# their configured GPU partition.
+# eval runner hosts the load balancer and PhysicsIntern subprocesses. It
+# defaults to hopper-prod because hopper-cpu runs on spot nodes that can be
+# preempted mid-eval; serve jobs still run on their configured GPU partition.
 
 set -euo pipefail
 
@@ -46,7 +47,7 @@ FRESH=""
 WORKSPACE_BASE=""
 NODES_PER_REPLICA=""
 KEEP_SERVES=""
-PARTITION="hopper-cpu"
+PARTITION="hopper-prod"
 DISCOVER_INTERVAL="600"
 
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
## Problem

Long-running CritPt eval wrapper jobs were being submitted to `hopper-cpu`, whose spot-backed nodes can disappear or be preempted mid-run. In practice, DeepSeek eval wrappers were cancelled with signal-style `ExitCode=0:10` while the model servers were still serving requests.

## Root cause

`serve/full_eval.slurm` defaulted the eval wrapper to `hopper-cpu`. That partition is appropriate for cheap CPU-only work, but it is a bad default for multi-hour eval orchestration because losing the wrapper tears down the load balancer and interrupts the run even when vLLM backends remain healthy.

## Solution

- Change the default eval wrapper partition in `serve/full_eval.slurm` from `hopper-cpu` to `hopper-prod`.
- Update README and documentation to explain that `hopper-prod` is the default to avoid spot/preemption cancellations, while still allowing an explicit `--partition` override.

## Testing

- Ran `bash -n serve/full_eval.slurm`.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only the default Slurm partition for the `serve/full_eval.slurm` eval wrapper plus related docs, with no impact to model serving logic or evaluation code paths beyond job scheduling defaults.
> 
> **Overview**
> Updates `serve/full_eval.slurm` so the CritPt *eval wrapper* (load balancer + PhysicsIntern subprocesses) defaults to the stable `hopper-prod` partition instead of spot-backed `hopper-cpu`, while still allowing explicit `--partition` overrides.
> 
> Refreshes README and `DOCUMENTATION.md` wording to match the new default and explain the preemption/spot motivation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e143d3bf0631cbbe45a09f272be865d236c1251. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->