### PR TITLE
Add DeepSeek high-reasoning eval option

### DIFF
--- a/serve/full_eval.slurm
+++ b/serve/full_eval.slurm
@@ -41,6 +41,7 @@ SERVE_JOBS=()
 CONCURRENCY="64"
 TIME_LIMIT="3-00:00:00"
 RESUME_DIR=""
+PROBLEMS=""
 RUNNER="oneshot"
 CONFIG_FILE=""
 FRESH=""
@@ -59,6 +60,7 @@ while [[ $# -gt 0 ]]; do
     --concurrency) CONCURRENCY="$2"; shift 2 ;;
     --time) TIME_LIMIT="$2"; shift 2 ;;
     --resume) RESUME_DIR="$2"; shift 2 ;;
+    --problems) PROBLEMS="$2"; shift 2 ;;
     --runner) RUNNER="$2"; shift 2 ;;
     --config) CONFIG_FILE="$2"; shift 2 ;;
     --fresh) FRESH="1"; shift ;;
@@ -76,7 +78,7 @@ done
 if [[ -z "$MODEL_KEY" ]]; then
   cat >&2 <<'USAGE'
 Usage: full_eval.slurm --model MODEL_KEY [--serve-job JOB_ID [--serve-job JOB_ID2 ...]]
-       [--concurrency N] [--time HH:MM:SS] [--resume DIR]
+       [--concurrency N] [--time HH:MM:SS] [--resume DIR] [--problems SPEC]
        [--runner oneshot|physicsintern] [--config CONFIG.yaml]
        [--fresh] [--workspace-base DIR] [--nodes-per-replica N]
        [--partition PARTITION] [--discover-interval SECONDS]
@@ -116,6 +118,9 @@ if [[ -z "${SLURM_JOB_ID:-}" ]]; then
   RESUME_ARG=()
   [[ -n "$RESUME_DIR" ]] && RESUME_ARG=(--resume "$RESUME_DIR")
 
+  PROBLEMS_ARG=()
+  [[ -n "$PROBLEMS" ]] && PROBLEMS_ARG=(--problems "$PROBLEMS")
+
   CONFIG_ARG=()
   [[ -n "$CONFIG_FILE" ]] && CONFIG_ARG=(--config "$CONFIG_FILE")
 
@@ -154,6 +159,7 @@ if [[ -z "${SLURM_JOB_ID:-}" ]]; then
                    --runner "$RUNNER" \
                    "${CONFIG_ARG[@]}" \
                    "${RESUME_ARG[@]}" \
+                   "${PROBLEMS_ARG[@]}" \
                    "${FRESH_ARG[@]}" \
                    "${WS_ARG[@]}" \
                    "${NPR_ARG[@]}" \
@@ -239,6 +245,9 @@ fi
 RESUME_ARG=()
 [[ -n "$RESUME_DIR" ]] && RESUME_ARG=(--resume "$RESUME_DIR")
 
+PROBLEMS_ARG=()
+[[ -n "$PROBLEMS" ]] && PROBLEMS_ARG=(--problems "$PROBLEMS")
+
 CONFIG_ARG=()
 [[ -n "$CONFIG_FILE" ]] && CONFIG_ARG=(--config "$CONFIG_FILE")
 
@@ -253,10 +262,12 @@ if [[ "$RUNNER" == "physicsintern" ]]; then
     --model "$MODEL_KEY" --concurrency "$CONCURRENCY" \
     "${CONFIG_ARG[@]}" \
     "${RESUME_ARG[@]}" \
+    "${PROBLEMS_ARG[@]}" \
     "${FRESH_ARG[@]}" \
     "${WS_ARG[@]}" && RUNNER_EXIT=0 || RUNNER_EXIT=$?
 else
   uv run --no-sync python scripts/run_critpt_oneshot.py \
     --model "$MODEL_KEY" --concurrency "$CONCURRENCY" --timeout 3600 \
-    "${RESUME_ARG[@]}" && RUNNER_EXIT=0 || RUNNER_EXIT=$?
+    "${RESUME_ARG[@]}" \
+    "${PROBLEMS_ARG[@]}" && RUNNER_EXIT=0 || RUNNER_EXIT=$?
 fi

--- a/serve/load_balancer.py
+++ b/serve/load_balancer.py
@@ -724,15 +724,15 @@ def create_app(pool: BackendPool, queue_timeout: float | None = None):
         max_attempts = max(1, pool.size)
         start_time = asyncio.get_event_loop().time()
         for _ in range(max_attempts):
-            if queue_timeout is not None:
+            if queue_timeout is None:
+                lease = await pool.acquire(timeout=None)
+            else:
                 elapsed = asyncio.get_event_loop().time() - start_time
                 remaining_timeout = max(0.0, queue_timeout - elapsed)
                 if remaining_timeout <= 0:
                     last_error = "Timed out waiting for backend capacity"
                     break
                 lease = await pool.acquire(timeout=remaining_timeout)
-            else:
-                lease = await pool.acquire(timeout=None)
             if lease is None:
                 last_error = "Timed out waiting for backend capacity"
                 break

--- a/src/physics_intern/models.yaml
+++ b/src/physics_intern/models.yaml
@@ -532,3 +532,39 @@ deepseek-ai/DeepSeek-V4-Pro:
       - throughput
       - --max-num-batched-tokens
       - '16384'
+
+deepseek-ai/DeepSeek-V4-Pro-high:
+  provider: vllm
+  model_id: deepseek-ai/DeepSeek-V4-Pro
+  env_key: VLLM_API_KEY
+  input_cost: 0.0
+  output_cost: 0.0
+  max_output_tokens: 131072
+  reasoning_format: separate_field
+  reasoning_effort: high
+  tool_mode: api
+  serve:
+    replicas: 4
+    nodes_per_replica: 4
+    gpus_per_node: 8
+    tp: 8
+    dp: 4
+    reasoning_parser: deepseek_v4
+    vllm_args:
+      - --max-model-len 262144
+      - --trust-remote-code
+      - --safetensors-load-strategy prefetch
+      - --enable-expert-parallel
+      - --enable-auto-tool-choice
+      - --tool-call-parser deepseek_v4
+      - --tokenizer-mode deepseek_v4
+      - --kv-cache-dtype fp8
+      - --block-size 256
+      - --default-chat-template-kwargs
+      - '{"thinking":true}'
+      - --compilation-config
+      - '{"cudagraph_mode":"PIECEWISE","max_cudagraph_capture_size":128,"inductor_compile_config":{"benchmark_combo_kernel":false}}'
+      - --performance-mode
+      - throughput
+      - --max-num-batched-tokens
+      - '16384'

--- a/src/physics_intern/providers/vllm.py
+++ b/src/physics_intern/providers/vllm.py
@@ -249,9 +249,12 @@ class VLLMProvider(LLMProvider):
         if tools and not use_xml:
             kwargs["tools"] = tools
             kwargs["tool_choice"] = "auto"
-        # Pass reasoning effort to the API if configured
+        # Pass reasoning effort to the OpenAI-compatible chat completions API
+        # when configured. The OpenAI Python client accepts this parameter
+        # directly; using the Responses-style {"reasoning": {"effort": ...}}
+        # shape would be rejected before reaching vLLM.
         if self._reasoning_effort:
-            kwargs["reasoning"] = {"effort": self._reasoning_effort}
+            kwargs["reasoning_effort"] = self._reasoning_effort
 
         stream = self._client.chat.completions.create(**kwargs)
 

--- a/src/physics_intern/providers/vllm.py
+++ b/src/physics_intern/providers/vllm.py
@@ -80,6 +80,7 @@ class VLLMProvider(LLMProvider):
         base_url: str = "http://localhost:8000/v1",
         timeout: float = 600.0,
         reasoning_format: str = "",
+        reasoning_effort: str = "",
         tool_mode: str = "api",
         **kwargs,
     ):
@@ -99,6 +100,7 @@ class VLLMProvider(LLMProvider):
             timeout=timeout,
         )
         self._reasoning_format = reasoning_format
+        self._reasoning_effort = reasoning_effort
         self._tool_mode = tool_mode
         # Tracks whether the most recent call() used xml_text tool mode.
         # Used by build_tool_result_messages() to choose message format.
@@ -247,6 +249,9 @@ class VLLMProvider(LLMProvider):
         if tools and not use_xml:
             kwargs["tools"] = tools
             kwargs["tool_choice"] = "auto"
+        # Pass reasoning effort to the API if configured
+        if self._reasoning_effort:
+            kwargs["reasoning"] = {"effort": self._reasoning_effort}
 
         stream = self._client.chat.completions.create(**kwargs)
 

--- a/tests/test_vllm_provider.py
+++ b/tests/test_vllm_provider.py
@@ -5,6 +5,38 @@ from types import SimpleNamespace
 from physics_intern.providers.vllm import VLLMProvider
 
 
+class _CaptureCompletions:
+    def __init__(self):
+        self.kwargs = None
+
+    def create(self, **kwargs):
+        self.kwargs = kwargs
+        delta = SimpleNamespace(
+            content="ok",
+            reasoning=None,
+            reasoning_content=None,
+            tool_calls=None,
+        )
+        choice = SimpleNamespace(delta=delta, finish_reason="stop")
+        usage = SimpleNamespace(prompt_tokens=1, completion_tokens=1)
+        return [SimpleNamespace(choices=[choice], usage=usage)]
+
+
+class _CaptureClient:
+    def __init__(self):
+        self.chat = SimpleNamespace(completions=_CaptureCompletions())
+
+
+def _make_provider(reasoning_effort: str = ""):
+    provider = object.__new__(VLLMProvider)
+    provider._client = _CaptureClient()
+    provider._reasoning_format = "separate_field"
+    provider._reasoning_effort = reasoning_effort
+    provider._tool_mode = "api"
+    provider._last_call_xml_tools = False
+    return provider
+
+
 # ---------------------------------------------------------------------------
 # XML tool-call parsing
 # ---------------------------------------------------------------------------
@@ -102,6 +134,53 @@ class TestParseXmlToolCalls:
         calls = VLLMProvider._parse_xml_tool_calls(text)
         assert len(calls) == 1
         assert calls[0]["name"] == "get_weather"
+
+
+class TestReasoningEffort:
+    def test_reasoning_effort_uses_chat_completions_parameter(self):
+        provider = _make_provider(reasoning_effort="high")
+
+        provider.call(
+            model="deepseek-ai/DeepSeek-V4-Pro",
+            max_tokens=16,
+            system="system",
+            messages=[],
+        )
+
+        kwargs = provider._client.chat.completions.kwargs
+        assert kwargs["reasoning_effort"] == "high"
+        assert "reasoning" not in kwargs
+
+    def test_reasoning_effort_is_omitted_when_unset(self):
+        provider = _make_provider()
+
+        provider.call(
+            model="deepseek-ai/DeepSeek-V4-Pro",
+            max_tokens=16,
+            system="system",
+            messages=[],
+        )
+
+        kwargs = provider._client.chat.completions.kwargs
+        assert "reasoning_effort" not in kwargs
+        assert "reasoning" not in kwargs
+
+    def test_high_and_max_reasoning_modes_send_distinct_values(self):
+        high_provider = _make_provider(reasoning_effort="high")
+        max_provider = _make_provider(reasoning_effort="max")
+
+        for provider in [high_provider, max_provider]:
+            provider.call(
+                model="deepseek-ai/DeepSeek-V4-Pro",
+                max_tokens=16,
+                system="system",
+                messages=[],
+            )
+
+        assert (
+            high_provider._client.chat.completions.kwargs["reasoning_effort"] == "high"
+        )
+        assert max_provider._client.chat.completions.kwargs["reasoning_effort"] == "max"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add support for small controlled evaluation experiments with DeepSeek V4 in
high-reasoning mode.

## Changes

- Add `deepseek-ai/DeepSeek-V4-Pro-high` to `models.yaml`.
  - Serves the same upstream model as `deepseek-ai/DeepSeek-V4-Pro`.
  - Uses `reasoning_effort: high` instead of `max`.
  - Reuses the existing stable vLLM serving configuration.

- Add `--problems` passthrough to `serve/full_eval.slurm`.
  - Allows subset runs such as `--problems 1-10`.
  - Applies to both `physicsintern` and `oneshot` runners.

- Keep the resolved load-balancer timeout behavior.
  - Queue timeout is treated as a total request budget across backend selection
    attempts, rather than being reset on each attempted backend.

## Test Plan

- `bash -n serve/full_eval.slurm`
- `uv run --no-sync python serve/resolve_serve_config.py deepseek-ai/DeepSeek-V4-Pro-high`
- `uv run --no-sync python -m pytest tests/test_load_balancer.py -q`
- `uv run --no-sync ruff check serve/load_balancer.py tests/test_load_balancer.py`
- `uv run --no-sync ruff format --check serve/load_balancer.py tests/test_load_balancer.py`
- `python -m py_compile serve/load_balancer.py`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes request routing/timeout behavior in the vLLM load balancer and alters vLLM provider request payloads (adds `reasoning.effort`), which can affect serving reliability and evaluation results.
> 
> **Overview**
> Adds a new `deepseek-ai/DeepSeek-V4-Pro-high` model entry to run the same DeepSeek V4 endpoint with `reasoning_effort: high` for controlled comparison against existing settings.
> 
> Extends `serve/full_eval.slurm` with a `--problems` passthrough so both `oneshot` and `physicsintern` runners can run a selected subset of benchmark problems.
> 
> Fixes the load balancer’s backend-acquire logic to treat `--queue-timeout` as a total budget across backend-selection attempts (and block indefinitely when unset), and updates the vLLM provider to forward configured `reasoning_effort` via the OpenAI-compatible `reasoning` request field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 528e9f476d94b3a9dff841e085cc49356a2aef73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->