### PR TITLE
Add Fair-Share vLLM Backend Launching

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -360,11 +360,18 @@ The DeepSeek entry in `models.yaml` supplies the production defaults:
   failure
 - `--performance-mode throughput` with `--max-num-batched-tokens 16384`
 
-With the default `replicas: 4`, `serve.slurm` dispatches through
-`serve/multi_serve.sh` and writes the four job IDs. Each replica writes its
-endpoint to `serve/logs/vllm/<job_id>/endpoint.env`; use
-`serve/load_balancer.py` or `serve/full_eval.slurm` with all four job IDs for a
-single `/v1` endpoint.
+With the default `replicas: 4`, `serve.slurm` treats those as the normal-QOS
+baseline and dispatches through `serve/multi_serve.sh`. The launcher also submits
+opportunistic low-QOS replicas with `--requeue`: by default it looks at idle
+`hopper-prod` nodes, subtracts the nodes needed by the normal replicas, divides
+the remaining nodes by `nodes_per_replica`, and submits at least two low-QOS
+replicas. Override the baseline with `--normal-replicas N`, override or disable
+opportunistic capacity with `--low-replicas N` or `--low-replicas 0`, and tune
+the auto minimum with `--low-min-replicas N`.
+
+Each replica writes its endpoint to `serve/logs/vllm/<job_id>/endpoint.env`; use
+`serve/load_balancer.py` or `serve/full_eval.slurm` with all job IDs for a single
+`/v1` endpoint.
 
 `serve.slurm` writes each replica endpoint to
 `serve/logs/vllm/<job_id>/endpoint.env` and Slurm logs to
@@ -431,14 +438,14 @@ srun --jobid=<EVAL_JOB_ID> --overlap --ntasks=1 --nodes=1 \
 ```
 
 The default DeepSeek config is tuned for high-concurrency CritPt-style traffic.
-To launch a single replica for debugging, override the replica count by calling
-`serve/multi_serve.sh` directly with `--replicas 1`, or call `serve.slurm` from
-inside `multi_serve.sh`.
+To launch a single replica for debugging, call `serve/multi_serve.sh` directly
+with `--normal-replicas 1 --low-replicas 0`.
 
 ```bash
 ./serve/multi_serve.sh \
   --model deepseek-ai/DeepSeek-V4-Pro \
-  --replicas 1 \
+  --normal-replicas 1 \
+  --low-replicas 0 \
   --nodes-per-replica 4
 ```
 
@@ -614,8 +621,8 @@ To go faster than the per-replica ceiling, use **external data parallelism**: ru
 Kimi-K2.6 does NOT fit on a single node (72 GiB weights per GPU; OOM even at 131k context). Native vLLM `--data-parallel-size` requires PP=1, so it cannot be used. Instead, launch N independent serve jobs and either use the load balancer or client-side round-robin:
 
 ```bash
-# Launch 8 replicas (4 nodes each = 32 nodes total)
-./serve/multi_serve.sh --model moonshotai/Kimi-K2.6 --replicas 8 --nodes-per-replica 4
+# Launch 4 normal-QOS replicas plus auto-sized low-QOS replicas.
+./serve/multi_serve.sh --model moonshotai/Kimi-K2.6 --normal-replicas 4 --nodes-per-replica 4
 
 # Benchmark with client-side round-robin across all replicas
 uv run python scripts/benchmark_throughput.py --serve-job <job1> <job2> <job3> <job4>

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ uv sync --extra all-providers   # all of the above
 uv sync --extra local
 
 # Serve DeepSeek V4 locally through vLLM on the H100 Slurm cluster.
-# This launches 4 external replicas behind the documented load-balancer flow.
+# This launches 4 normal-QOS replicas plus auto-sized low-QOS requeueable
+# replicas from currently idle capacity.
 # See DOCUMENTATION.md for the required cu129 vLLM install and DeepGEMM wheel.
 # Idle serve replicas auto-cancel after 2 hours without completed, running, or waiting requests.
 # Queued replacements wait without timing out; failed replacements are cancelled before resubmit.

--- a/serve/multi_serve.sh
+++ b/serve/multi_serve.sh
@@ -5,8 +5,8 @@
 # replicas start, a combined endpoint file is written with all BASE_URLs.
 #
 # Usage:
-#   ./serve/multi_serve.sh --model moonshotai/Kimi-K2.6 --replicas 4 --nodes-per-replica 4
-#   ./serve/multi_serve.sh --model moonshotai/Kimi-K2.6 --replicas 8 --nodes-per-replica 4
+#   ./serve/multi_serve.sh --model moonshotai/Kimi-K2.6 --normal-replicas 4 --nodes-per-replica 4
+#   ./serve/multi_serve.sh --model moonshotai/Kimi-K2.6 --normal-replicas 4 --low-replicas auto --nodes-per-replica 4
 #
 # Output: serve/logs/vllm/multi-<TIMESTAMP>/endpoints.env
 #   Contains BASE_URLS=url1,url2,...,urlN for the load balancer or benchmark script.
@@ -19,9 +19,14 @@ SERVE_SCRIPT="${SCRIPT_DIR}/serve.slurm"
 LOG_ROOT="${REPO_ROOT}/serve/logs"
 
 MODEL=""
-REPLICAS=""
+NORMAL_REPLICAS=""
+LOW_REPLICAS="auto"
+LOW_MIN_REPLICAS="2"
 NODES_PER_REPLICA=""
 GPUS_PER_NODE="8"
+PARTITION="hopper-prod"
+NORMAL_QOS="normal"
+LOW_QOS="low"
 TIME_LIMIT="24:00:00"
 IDLE_SHUTDOWN="7200"
 MAX_NUM_SEQS=""
@@ -30,20 +35,26 @@ EXTRA_ARGS=()
 usage() {
   cat <<'USAGE'
 Usage:
-  ./serve/multi_serve.sh --model MODEL --replicas N --nodes-per-replica K [options] [-- ...extra vllm args]
+  ./serve/multi_serve.sh --model MODEL --normal-replicas N --low-replicas N|auto --nodes-per-replica K [options] [-- ...extra vllm args]
 
 Examples:
-  # 4 replicas of Kimi (4 nodes each = 16 nodes total, default)
-  ./serve/multi_serve.sh --model moonshotai/Kimi-K2.6 --replicas 4 --nodes-per-replica 4
+  # 4 normal-QOS replicas plus auto-sized low-QOS replicas from idle capacity
+  ./serve/multi_serve.sh --model moonshotai/Kimi-K2.6 --normal-replicas 4 --nodes-per-replica 4
 
-  # 8 replicas of Kimi (4 nodes each = 32 nodes total)
-  ./serve/multi_serve.sh --model moonshotai/Kimi-K2.6 --replicas 8 --nodes-per-replica 4
+  # 4 normal-QOS replicas only
+  ./serve/multi_serve.sh --model moonshotai/Kimi-K2.6 --normal-replicas 4 --low-replicas 0 --nodes-per-replica 4
 
 Options:
   --model MODEL               Model to serve (required).
-  --replicas N                Number of independent replicas (required).
+  --normal-replicas N         Number of normal-QOS replicas.
+  --low-replicas N|auto       Number of low-QOS replicas, or "auto" to use
+                              idle nodes after normal replicas (default: auto).
+  --low-min-replicas N        Minimum low-QOS replicas in auto mode (default: 2).
   --nodes-per-replica K       Nodes per replica (required).
   --gpus-per-node N           GPUs per node (default: 8).
+  --partition NAME            Slurm partition (default: hopper-prod).
+  --normal-qos NAME           QOS for normal replicas (default: normal).
+  --low-qos NAME              QOS for opportunistic replicas (default: low).
   --time HH:MM:SS             Slurm time limit (default: 24:00:00).
   --idle-shutdown SECONDS     Idle watchdog timeout (default: 7200).
   --max-num-seqs N            Max concurrent sequences per replica.
@@ -54,9 +65,14 @@ USAGE
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --model) MODEL="$2"; shift 2 ;;
-    --replicas) REPLICAS="$2"; shift 2 ;;
+    --normal-replicas) NORMAL_REPLICAS="$2"; shift 2 ;;
+    --low-replicas) LOW_REPLICAS="$2"; shift 2 ;;
+    --low-min-replicas) LOW_MIN_REPLICAS="$2"; shift 2 ;;
     --nodes-per-replica) NODES_PER_REPLICA="$2"; shift 2 ;;
     --gpus-per-node) GPUS_PER_NODE="$2"; shift 2 ;;
+    --partition) PARTITION="$2"; shift 2 ;;
+    --normal-qos) NORMAL_QOS="$2"; shift 2 ;;
+    --low-qos) LOW_QOS="$2"; shift 2 ;;
     --time) TIME_LIMIT="$2"; shift 2 ;;
     --idle-shutdown) IDLE_SHUTDOWN="$2"; shift 2 ;;
     --max-num-seqs) MAX_NUM_SEQS="$2"; shift 2 ;;
@@ -66,33 +82,77 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ -z "$MODEL" || -z "$REPLICAS" || -z "$NODES_PER_REPLICA" ]]; then
+if [[ -z "$MODEL" || -z "$NORMAL_REPLICAS" || -z "$NODES_PER_REPLICA" ]]; then
   echo "Missing required arguments." >&2
   usage
   exit 1
 fi
 
+if [[ ! "$NORMAL_REPLICAS" =~ ^[0-9]+$ || "$NORMAL_REPLICAS" -lt 0 ]]; then
+  echo "--normal-replicas must be a non-negative integer." >&2
+  exit 1
+fi
+if [[ "$LOW_REPLICAS" != "auto" && ( ! "$LOW_REPLICAS" =~ ^[0-9]+$ || "$LOW_REPLICAS" -lt 0 ) ]]; then
+  echo "--low-replicas must be a non-negative integer or 'auto'." >&2
+  exit 1
+fi
+if [[ ! "$LOW_MIN_REPLICAS" =~ ^[0-9]+$ ]]; then
+  echo "--low-min-replicas must be a non-negative integer." >&2
+  exit 1
+fi
+
+IDLE_NODES=""
+if [[ "$LOW_REPLICAS" == "auto" ]]; then
+  IDLE_NODES="$(sinfo -h -p "$PARTITION" -t idle -o "%D" | awk '{ total += $1 } END { print total + 0 }')"
+  RESERVED_NORMAL_NODES=$(( NORMAL_REPLICAS * NODES_PER_REPLICA ))
+  REMAINING_NODES=$(( IDLE_NODES - RESERVED_NORMAL_NODES ))
+  if (( REMAINING_NODES > 0 )); then
+    LOW_REPLICAS=$(( REMAINING_NODES / NODES_PER_REPLICA ))
+  else
+    LOW_REPLICAS=0
+  fi
+  if (( LOW_REPLICAS < LOW_MIN_REPLICAS )); then
+    LOW_REPLICAS="$LOW_MIN_REPLICAS"
+  fi
+fi
+
+REPLICAS=$(( NORMAL_REPLICAS + LOW_REPLICAS ))
 TOTAL_NODES=$(( REPLICAS * NODES_PER_REPLICA ))
 TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
 MULTI_DIR="${LOG_ROOT}/vllm/multi-${TIMESTAMP}"
 mkdir -p "$MULTI_DIR"
 
 echo "Launching ${REPLICAS} replica(s) of ${MODEL}"
+echo "  Normal replicas:   ${NORMAL_REPLICAS} (qos=${NORMAL_QOS})"
+echo "  Low replicas:      ${LOW_REPLICAS} (qos=${LOW_QOS}, requeue=on)"
+if [[ -n "$IDLE_NODES" ]]; then
+  echo "  Idle ${PARTITION} nodes: ${IDLE_NODES}"
+fi
 echo "  Nodes per replica: ${NODES_PER_REPLICA}"
 echo "  Total nodes:       ${TOTAL_NODES}"
 echo "  Output dir:        ${MULTI_DIR}"
 echo "---"
 
 JOB_IDS=()
-for i in $(seq 1 "$REPLICAS"); do
+submit_replica() {
+  local replica_idx="$1"
+  local total_replicas="$2"
+  local qos="$3"
+  local requeue="$4"
+  local label="$5"
   SERVE_ARGS=(
     "$SERVE_SCRIPT"
     --model "$MODEL"
     --nodes "$NODES_PER_REPLICA"
     --gpus-per-node "$GPUS_PER_NODE"
+    --partition "$PARTITION"
+    --qos "$qos"
     --time "$TIME_LIMIT"
     --idle-shutdown "$IDLE_SHUTDOWN"
   )
+  if [[ "$requeue" == "1" ]]; then
+    SERVE_ARGS+=(--requeue)
+  fi
   if [[ -n "$MAX_NUM_SEQS" ]]; then
     SERVE_ARGS+=(-- --max-num-seqs "$MAX_NUM_SEQS" "${EXTRA_ARGS[@]}")
   elif [[ ${#EXTRA_ARGS[@]} -gt 0 ]]; then
@@ -101,16 +161,31 @@ for i in $(seq 1 "$REPLICAS"); do
 
   JOB_ID=$(_MULTI_SERVE_PARENT=1 "${SERVE_ARGS[@]}" 2>&1 | grep -oP 'Submitted \K\d+')
   JOB_IDS+=("$JOB_ID")
-  echo "Replica ${i}/${REPLICAS}: job ${JOB_ID}"
+  echo "Replica ${replica_idx}/${total_replicas} [${label}]: job ${JOB_ID}"
+}
+
+replica_i=0
+for _ in $(seq 1 "$NORMAL_REPLICAS"); do
+  replica_i=$((replica_i + 1))
+  submit_replica "$replica_i" "$REPLICAS" "$NORMAL_QOS" "0" "normal"
+done
+for _ in $(seq 1 "$LOW_REPLICAS"); do
+  replica_i=$((replica_i + 1))
+  submit_replica "$replica_i" "$REPLICAS" "$LOW_QOS" "1" "low"
 done
 
 # Write multi-serve metadata.
 cat >"${MULTI_DIR}/multi_serve.env" <<EOF
 MODEL=${MODEL}
 REPLICAS=${REPLICAS}
+NORMAL_REPLICAS=${NORMAL_REPLICAS}
+LOW_REPLICAS=${LOW_REPLICAS}
 NODES_PER_REPLICA=${NODES_PER_REPLICA}
 TOTAL_NODES=${TOTAL_NODES}
 JOB_IDS=${JOB_IDS[*]}
+PARTITION=${PARTITION}
+NORMAL_QOS=${NORMAL_QOS}
+LOW_QOS=${LOW_QOS}
 MAX_NUM_SEQS=${MAX_NUM_SEQS:-default}
 TIMESTAMP=${TIMESTAMP}
 EOF

--- a/serve/serve.slurm
+++ b/serve/serve.slurm
@@ -450,21 +450,17 @@ if [[ -z "${SLURM_JOB_ID:-}" ]]; then
     GPUS_PER_NODE="$DEFAULT_GPUS_PER_NODE"
   fi
 
-  # Auto-dispatch to multi_serve.sh for models with replicas > 1
-  # (e.g. Kimi-K2.6 uses 4 external-DP replicas with PP=2 each).
+  # Auto-dispatch to multi_serve.sh for normal serving pools. A single normal
+  # replica is an explicit debug job, so keep it as one exact serve job and do
+  # not add opportunistic low-QOS replicas.
   # Suppressed when called from multi_serve.sh to avoid infinite recursion.
   REPLICAS="${NORMAL_REPLICAS:-${DEFAULT_REPLICAS:-1}}"
-  DISPATCH_MULTI=0
-  if [[ -z "${_MULTI_SERVE_PARENT:-}" ]]; then
-    if is_pos_int "$REPLICAS" && (( REPLICAS > 1 )); then
-      DISPATCH_MULTI=1
-    elif [[ "$LOW_REPLICAS" == "auto" ]]; then
-      DISPATCH_MULTI=1
-    elif is_pos_int "$LOW_REPLICAS" && (( LOW_REPLICAS > 0 )); then
-      DISPATCH_MULTI=1
-    fi
+  DEBUG_SINGLE_REPLICA=0
+  if is_pos_int "$REPLICAS" && (( REPLICAS == 1 )); then
+    DEBUG_SINGLE_REPLICA=1
+    LOW_REPLICAS="0"
   fi
-  if (( DISPATCH_MULTI )); then
+  if [[ -z "${_MULTI_SERVE_PARENT:-}" ]] && (( ! DEBUG_SINGLE_REPLICA )) && is_pos_int "$REPLICAS" && (( REPLICAS > 1 )); then
     MULTI_SERVE="${SCRIPT_DIR}/multi_serve.sh"
     MULTI_ARGS=(
       "$MULTI_SERVE"

--- a/serve/serve.slurm
+++ b/serve/serve.slurm
@@ -59,6 +59,14 @@ Options:
                                    (default: 7200 = 2h; 0 disables).
   --max-restarts N                 Restart vLLM up to N times on crash
                                    (default: VLLM_MAX_RESTARTS or 3).
+  --qos NAME                       Slurm QOS for a single serve job.
+  --requeue                        Submit a single serve job as requeueable.
+  --normal-replicas N              Auto-dispatch N normal-QOS replicas
+                                   (default: serve.replicas).
+  --low-replicas N|auto            Auto-dispatch low-QOS replicas. "auto"
+                                   uses idle nodes after normal replicas
+                                   (default: auto; 0 disables).
+  --low-min-replicas N             Minimum auto low-QOS replicas (default: 2).
   -h, --help                       Show this message.
   --                               Extra args passed through to vllm serve.
 
@@ -264,6 +272,11 @@ PORT="8000"
 SERVED_MODEL_NAME=""
 MAX_MODEL_LEN="262144"
 MAX_MODEL_LEN_EXPLICIT=""
+QOS=""
+REQUEUE=""
+NORMAL_REPLICAS=""
+LOW_REPLICAS="auto"
+LOW_MIN_REPLICAS="2"
 TP=""
 PP=""
 DP=""
@@ -350,6 +363,30 @@ while [[ $# -gt 0 ]]; do
       export VLLM_MAX_RESTARTS="$2"
       shift 2
       ;;
+    --qos)
+      require_value "$1" "${2:-}"
+      QOS="$2"
+      shift 2
+      ;;
+    --requeue)
+      REQUEUE="1"
+      shift
+      ;;
+    --normal-replicas)
+      require_value "$1" "${2:-}"
+      NORMAL_REPLICAS="$2"
+      shift 2
+      ;;
+    --low-replicas)
+      require_value "$1" "${2:-}"
+      LOW_REPLICAS="$2"
+      shift 2
+      ;;
+    --low-min-replicas)
+      require_value "$1" "${2:-}"
+      LOW_MIN_REPLICAS="$2"
+      shift 2
+      ;;
     -h|--help)
       usage
       exit 0
@@ -416,15 +453,18 @@ if [[ -z "${SLURM_JOB_ID:-}" ]]; then
   # Auto-dispatch to multi_serve.sh for models with replicas > 1
   # (e.g. Kimi-K2.6 uses 4 external-DP replicas with PP=2 each).
   # Suppressed when called from multi_serve.sh to avoid infinite recursion.
-  REPLICAS="${DEFAULT_REPLICAS:-1}"
+  REPLICAS="${NORMAL_REPLICAS:-${DEFAULT_REPLICAS:-1}}"
   if [[ -z "${_MULTI_SERVE_PARENT:-}" ]] && is_pos_int "$REPLICAS" && (( REPLICAS > 1 )); then
     MULTI_SERVE="${SCRIPT_DIR}/multi_serve.sh"
     MULTI_ARGS=(
       "$MULTI_SERVE"
       --model "$MODEL"
-      --replicas "$REPLICAS"
+      --normal-replicas "$REPLICAS"
+      --low-replicas "$LOW_REPLICAS"
+      --low-min-replicas "$LOW_MIN_REPLICAS"
       --nodes-per-replica "$NODES"
       --gpus-per-node "$GPUS_PER_NODE"
+      --partition "$PARTITION"
       --time "$TIME_LIMIT"
       --idle-shutdown "$IDLE_SHUTDOWN_SECONDS"
     )
@@ -481,6 +521,14 @@ if [[ -z "${SLURM_JOB_ID:-}" ]]; then
     --time "$TIME_LIMIT"
     --output "${LOG_DIR_DEFAULT}/%x-%j.out"
     --error "${LOG_DIR_DEFAULT}/%x-%j.err"
+  )
+  if [[ -n "$QOS" ]]; then
+    SUBMIT_CMD+=(--qos "$QOS")
+  fi
+  if [[ -n "$REQUEUE" ]]; then
+    SUBMIT_CMD+=(--requeue)
+  fi
+  SUBMIT_CMD+=(
     "$SCRIPT_PATH"
     "${ORIGINAL_ARGS[@]}"
   )

--- a/serve/serve.slurm
+++ b/serve/serve.slurm
@@ -454,7 +454,17 @@ if [[ -z "${SLURM_JOB_ID:-}" ]]; then
   # (e.g. Kimi-K2.6 uses 4 external-DP replicas with PP=2 each).
   # Suppressed when called from multi_serve.sh to avoid infinite recursion.
   REPLICAS="${NORMAL_REPLICAS:-${DEFAULT_REPLICAS:-1}}"
-  if [[ -z "${_MULTI_SERVE_PARENT:-}" ]] && is_pos_int "$REPLICAS" && (( REPLICAS > 1 )); then
+  DISPATCH_MULTI=0
+  if [[ -z "${_MULTI_SERVE_PARENT:-}" ]]; then
+    if is_pos_int "$REPLICAS" && (( REPLICAS > 1 )); then
+      DISPATCH_MULTI=1
+    elif [[ "$LOW_REPLICAS" == "auto" ]]; then
+      DISPATCH_MULTI=1
+    elif is_pos_int "$LOW_REPLICAS" && (( LOW_REPLICAS > 0 )); then
+      DISPATCH_MULTI=1
+    fi
+  fi
+  if (( DISPATCH_MULTI )); then
     MULTI_SERVE="${SCRIPT_DIR}/multi_serve.sh"
     MULTI_ARGS=(
       "$MULTI_SERVE"


### PR DESCRIPTION
## Problem

Large DeepSeek/Kimi serving runs can consume many `normal` QOS nodes, which makes life harder for other cluster users because those jobs are not as easy to preempt. We still want a stable baseline of backends, but burst capacity should use lower-priority, requeueable jobs.

## Root cause

`serve.slurm` treated `serve.replicas` as the total backend count and submitted every replica with the same default Slurm priority. There was no built-in distinction between stable baseline capacity and opportunistic capacity that can yield to higher-priority work.

## Solution

- Treat `serve.replicas` as the normal-QOS baseline when `serve.slurm` auto-dispatches multiple replicas.
- Add `multi_serve.sh` support for `--normal-replicas`, `--low-replicas`, and `--low-min-replicas`.
- In `--low-replicas auto` mode, compute low-QOS capacity from idle nodes after reserving the normal baseline, with a minimum of two low-QOS replicas.
- Submit low-QOS replicas with `--qos low --requeue`.
- Add `serve.slurm` passthroughs for `--qos`, `--requeue`, and the new normal/low replica controls.
- Treat `--normal-replicas 1` as an explicit debug launch and disable low-QOS auto capacity for that single serve job.
- Update README and documentation with the new fair-share launch policy and examples.

## Testing

- Ran `bash -n serve/serve.slurm serve/multi_serve.sh serve/full_eval.slurm`.
- Ran `git diff --check`.
- Ran `./serve/multi_serve.sh --help` and `./serve/serve.slurm --help`.
